### PR TITLE
Add confirmation tool, update system prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neur-app",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "scripts": {
     "vercel-build": "pnpm npx prisma generate && next build",

--- a/src/ai/generic/util.tsx
+++ b/src/ai/generic/util.tsx
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+// Tools Export
+export const utilTools = {
+  askForConfirmation: {
+    displayName: '⚠️ Confirmation',
+    description: 'Confirm the execution of a function on behalf of the user.',
+    parameters: z.object({
+      message: z.string().describe('The message to ask for confirmation'),
+    }),
+    execute: async ({ message }: { message: string }) => {
+      return {
+        data: {
+          message,
+        },
+      };
+    },
+    render: (raw: unknown) => {
+      const result = raw as { data: { message: string } };
+
+      return (
+        <div className="relative overflow-hidden rounded-2xl bg-muted/50 p-4">
+          <div className="flex items-center gap-3">
+            <p className="text-sm text-muted-foreground">
+              {result.data.message}
+            </p>
+          </div>
+        </div>
+      );
+    },
+  },
+};

--- a/src/ai/providers.tsx
+++ b/src/ai/providers.tsx
@@ -5,6 +5,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { z } from 'zod';
 
 import { jinaTools } from './generic/jina';
+import { utilTools } from './generic/util';
 import { definedTools } from './solana/defined-fi';
 import { dexscreenerTools } from './solana/dexscreener';
 import { jupiterTools } from './solana/jupiter';
@@ -35,6 +36,12 @@ Critical Rules:
      - "The results are shown above"
      - "You can see the details above"
 - Always use the \`searchToken\` tool to get the correct token mint first and ask for user confirmation.
+- Always use the \`askForConfirmation\` tool to get user confirmation before executing tools that contain the parameter "requiresConfirmation" set to "true", or are potentially risky. After calling \`askForConfirmation\`:
+     - STOP your response immediately
+     - Wait for the user to explicitly reply with a confirmation or rejection
+     - Only proceed with the tool execution in a NEW response after receiving an explicit confirmation
+     - If rejected, acknowledge the rejection and stop
+     - Never chain the confirmation request and the tool execution in the same response
 
 Response Formatting:
 - Use proper line breaks between different sections of your response for better readability
@@ -64,6 +71,7 @@ export interface ToolConfig {
     params: z.infer<T extends z.ZodType ? T : never>,
   ) => Promise<any>;
   render?: (result: unknown) => React.ReactNode | null;
+  requiresConfirmation?: boolean;
 }
 
 export function DefaultToolResultRenderer({ result }: { result: unknown }) {
@@ -92,6 +100,7 @@ export const defaultTools: Record<string, ToolConfig> = {
   ...dexscreenerTools,
   ...magicEdenTools,
   ...jinaTools,
+  ...utilTools,
 };
 
 export function getToolConfig(toolName: string): ToolConfig | undefined {

--- a/src/ai/solana/pumpfun.tsx
+++ b/src/ai/solana/pumpfun.tsx
@@ -88,6 +88,7 @@ export const pumpfunTools = {
     description: 'Launch a token on PumpFun',
     displayName: '💊 Deploy new token',
     parameters: z.object({
+      requiresConfirmation: z.boolean().optional().default(true),
       name: z.string().describe('The name of the token'),
       symbol: z.string().describe('The symbol of the token'),
       description: z.string().describe('The description of the token'),

--- a/src/ai/solana/solana.tsx
+++ b/src/ai/solana/solana.tsx
@@ -344,6 +344,7 @@ const swap = {
     displayName: '🪙 Swap Tokens',
     description: 'Swap tokens using Jupiter Exchange with the embedded wallet.',
     parameters: z.object({
+      requiresConfirmation: z.boolean().optional().default(true),
       inputMint: publicKeySchema.describe('Source token mint address'),
       outputMint: publicKeySchema.describe('Target token mint address'),
       amount: z.number().positive().describe('Amount to swap'),


### PR DESCRIPTION
Fairly straightforward, please review updated system prompt. By default the confirmation will apply to swaps and PF token creation, and anything else deemed risky by the AI.