### PR TITLE
Limit messages in context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neur-app",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "scripts": {
     "vercel-build": "pnpm npx prisma generate && next build",

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -30,6 +30,7 @@ import {
 } from '@/server/db/queries';
 
 export const maxDuration = 30;
+export const maxMessages = 5;
 
 export async function POST(req: Request) {
   const session = await verifyUser();
@@ -95,6 +96,11 @@ export async function POST(req: Request) {
       `\n\nHistory of attachments: ${JSON.stringify(attachments)}` +
       `\n\nUser Solana wallet public key: ${publicKey}`;
 
+    // Filter to relevant messages for context sizing
+    const relevantMessages: CoreMessage[] = coreMessages.slice(
+      -maxMessages,
+    ) as CoreMessage[];
+
     const result = streamText({
       model: defaultModel,
       system: systemPrompt,
@@ -137,7 +143,7 @@ export async function POST(req: Request) {
       },
 
       maxSteps: 15,
-      messages,
+      messages: relevantMessages,
       async onFinish({ response }) {
         if (!userId) return;
 

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -16,6 +16,7 @@ import {
   defaultSystemPrompt,
   defaultTools,
 } from '@/ai/providers';
+import { MAX_TOKEN_MESSAGES } from '@/lib/constants';
 import {
   getMostRecentUserMessage,
   sanitizeResponseMessages,
@@ -30,7 +31,6 @@ import {
 } from '@/server/db/queries';
 
 export const maxDuration = 30;
-export const maxMessages = 5;
 
 export async function POST(req: Request) {
   const session = await verifyUser();
@@ -98,7 +98,7 @@ export async function POST(req: Request) {
 
     // Filter to relevant messages for context sizing
     const relevantMessages: CoreMessage[] = coreMessages.slice(
-      -maxMessages,
+      -MAX_TOKEN_MESSAGES,
     ) as CoreMessage[];
 
     const result = streamText({

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,3 +6,5 @@ export const IS_BETA = true;
 export const RPC_URL =
   process.env.NEXT_PUBLIC_HELIUS_RPC_URL ||
   'https://api.mainnet-beta.solana.com';
+
+export const MAX_TOKEN_MESSAGES = 5;


### PR DESCRIPTION
Quick fix for limiting context size. Can adjust as needed - expecting longer term solution will be building another server that manages/indexes context for us (summarization, keyword extraction, etc).

This shouldn't affect most common use cases for now, but is needed to prevent us from bumping into rate limits.