### PR TITLE
Fix message context trimming for gpt4o

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -1,5 +1,9 @@
 # Changelogs
 
+## v0.1.9
+
+- Use correct messages when trimming the message context for gpt4o
+
 ## v0.1.8
 
 - Improve conversation API route usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neur-app",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "scripts": {
     "vercel-build": "pnpm npx prisma generate && next build",

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -97,7 +97,7 @@ export async function POST(req: Request) {
       `\n\nUser Solana wallet public key: ${publicKey}`;
 
     // Filter to relevant messages for context sizing
-    const relevantMessages: CoreMessage[] = coreMessages.slice(
+    const relevantMessages: CoreMessage[] = messages.slice(
       -MAX_TOKEN_MESSAGES,
     ) as CoreMessage[];
 


### PR DESCRIPTION
For some reason passing the coreMessages was working for anthropic, but not gpt. Quick fix here, seems to resolve the issue