### PR TITLE
Refresh chat via polling

### DIFF
--- a/src/app/(user)/chat/[id]/chat-interface.tsx
+++ b/src/app/(user)/chat/[id]/chat-interface.tsx
@@ -29,6 +29,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { useWalletPortfolio } from '@/hooks/use-wallet-portfolio';
 import { uploadImage } from '@/lib/upload';
 import { cn, throttle } from '@/lib/utils';
+import usePolling from '@/hooks/use-polling';
 
 // Types
 interface UploadingImage extends Attachment {
@@ -552,7 +553,7 @@ export default function ChatInterface({
   id: string;
   initialMessages?: Message[];
 }) {
-  const { messages, input, handleSubmit, handleInputChange, isLoading } =
+  const { messages, input, handleSubmit, handleInputChange, isLoading, setMessages } =
     useChat({
       id,
       initialMessages,
@@ -563,6 +564,16 @@ export default function ChatInterface({
         refresh();
       },
     });
+
+  // Use polling for fetching new messages
+  usePolling({
+    id,
+    onUpdate: (messages) => {
+      if (messages && messages.length) {
+        setMessages(messages);
+      }
+    }
+  });
 
   const [previewImage, setPreviewImage] = useState<ImagePreview | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);

--- a/src/app/api/chat/[conversationId]/route.ts
+++ b/src/app/api/chat/[conversationId]/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { verifyUser } from '@/server/actions/user';
+
+import {
+  dbGetConversation,
+} from '@/server/db/queries';
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ conversationId: string }> }) {
+  const session = await verifyUser();
+  const userId = session?.data?.data?.id;
+  const publicKey = session?.data?.data?.publicKey;
+
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!publicKey) {
+    console.error('[chat/route] No public key found');
+    return NextResponse.json({ error: 'No public key found' }, { status: 400 });
+  }
+
+  const { conversationId } = await params;
+
+  if (!conversationId) {
+    return NextResponse.json({ error: 'Missing conversationId' }, { status: 401 });
+  }
+
+  try {
+    const conversation = await dbGetConversation({ conversationId, includeMessages: true });
+
+    if (!conversation) {
+      return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(conversation);
+  } catch (error) {
+    console.error(`[chat/[conversationId]/route] Error fetching conversation: ${error}`);
+    return NextResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -156,7 +156,7 @@ export async function POST(req: Request) {
           );
 
           // Create messages and get their IDs back
-          const messages = await dbCreateMessages({
+          const newMessages = await dbCreateMessages({
             messages: sanitizedResponses.map((message) => {
               return {
                 conversationId,
@@ -168,14 +168,14 @@ export async function POST(req: Request) {
 
           // Save the token stats
           if (
-            messages &&
+            newMessages &&
             newUserMessage &&
             !isNaN(usage.promptTokens) &&
             !isNaN(usage.completionTokens) &&
             !isNaN(usage.totalTokens)
           ) {
             const messageIds = newUserMessage
-              .concat(messages)
+              .concat(newMessages)
               .map((message) => message.id);
             const { promptTokens, completionTokens, totalTokens } = usage;
 

--- a/src/hooks/use-polling.ts
+++ b/src/hooks/use-polling.ts
@@ -1,29 +1,28 @@
-import { convertToUIMessages } from '@/lib/utils/ai';
 import { useEffect } from 'react';
 
 type UsePollingOptions = {
+  url: string;
   id: string;
   onUpdate: (newData: any) => void;
   interval?: number;
 };
 
-const usePolling = ({ id, onUpdate, interval = 60000 }: UsePollingOptions) => {
+const usePolling = ({
+  url,
+  id,
+  onUpdate,
+  interval = 60000,
+}: UsePollingOptions) => {
   useEffect(() => {
     const poll = async () => {
       try {
-        const response = await fetch(`/api/chat/${id}`);
+        const response = await fetch(url);
         if (!response.ok) {
           return;
         }
         const data = await response.json();
 
-        if (!data || !data.messages) {
-          return;
-        }
-        
-        const messages = convertToUIMessages(data?.messages);
-
-        onUpdate(messages); // Pass fetched data to the callback
+        onUpdate(data); // Pass fetched data to the callback
       } catch (_) {
         // Intentionally ignore the error
       }

--- a/src/hooks/use-polling.ts
+++ b/src/hooks/use-polling.ts
@@ -1,0 +1,37 @@
+import { convertToUIMessages } from '@/lib/utils/ai';
+import { useEffect } from 'react';
+
+type UsePollingOptions = {
+  id: string;
+  onUpdate: (newData: any) => void;
+  interval?: number;
+};
+
+const usePolling = ({ id, onUpdate, interval = 60000 }: UsePollingOptions) => {
+  useEffect(() => {
+    const poll = async () => {
+      try {
+        const response = await fetch(`/api/chat/${id}`);
+        if (!response.ok) {
+          return;
+        }
+        const data = await response.json();
+
+        if (!data || !data.messages) {
+          return;
+        }
+        
+        const messages = convertToUIMessages(data?.messages);
+
+        onUpdate(messages); // Pass fetched data to the callback
+      } catch (_) {
+        // Intentionally ignore the error
+      }
+    };
+
+    const pollingInterval = setInterval(poll, interval);
+    return () => clearInterval(pollingInterval); // Cleanup interval on unmount
+  }, [id, onUpdate, interval]);
+};
+
+export default usePolling;

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -12,12 +12,15 @@ import { NewAction } from '@/types/db';
  */
 export async function dbGetConversation({
   conversationId,
+  includeMessages
 }: {
   conversationId: string;
+  includeMessages?: boolean;
 }) {
   try {
     return await prisma.conversation.findUnique({
       where: { id: conversationId },
+      include: includeMessages ? { messages: true } : undefined,
     });
   } catch (error) {
     console.error('[DB Error] Failed to get conversation:', {


### PR DESCRIPTION
Closes #76 

Seems to work in a normal chat flow scenario - and does get the new messages when an action executes.

One quirk is some small UI flickering when rerendering (possibly because when updating the messages the data changes, since user message IDs are first generated on the client)

This is an implementation using polling that hits the server every 60s by default to get messages - if a conversation continues during the window between polling the messages might seem like they're out of order to the user.

A better implementation would be using some sort of pub/sub mechanism, not sure what our options are for that on Vercel