### PR TITLE
[Fix] Refresh action list on conversation delete

### DIFF
--- a/src/ai/generic/action.tsx
+++ b/src/ai/generic/action.tsx
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 
+import { ActionEmitter } from '@/components/action-emitter';
 import { Card } from '@/components/ui/card';
 import { verifyUser } from '@/server/actions/user';
 import { dbCreateAction } from '@/server/db/queries';
-import { useActionStore } from '@/store/action-store';
-import { emitActionCreated } from '@/lib/events';
-import { ActionEmitter } from '@/components/action-emitter';
 
 interface CreateActionResultProps {
   id: string;
@@ -168,13 +166,14 @@ const createActionTool = {
         return { success: false, error: 'Failed to create action' };
       }
 
-      
       return { success: true, data: action };
     } catch (error: any) {
-      
       return {
         success: false,
-        error: error instanceof Error ? error.message : 'Unknown error creating action',
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Unknown error creating action',
       };
     }
   },

--- a/src/ai/generic/telegram.tsx
+++ b/src/ai/generic/telegram.tsx
@@ -105,7 +105,10 @@ export const telegramTools = {
     }),
     execute: async function ({ username }: { username?: string }) {
       try {
-        const response = await verifyTelegramSetupAction({ username, userId: this.userId || undefined });
+        const response = await verifyTelegramSetupAction({
+          username,
+          userId: this.userId || undefined,
+        });
         if (!response?.data?.data) {
           return { success: false, error: 'No response from Telegram action' };
         }

--- a/src/ai/solana/pumpfun.tsx
+++ b/src/ai/solana/pumpfun.tsx
@@ -1,7 +1,8 @@
-import { Card } from '@/components/ui/card';
-import { LaunchResult } from '@/components/message/pumpfun-launch';
-import { retrieveAgentKit } from '@/server/actions/ai';
 import { z } from 'zod';
+
+import { LaunchResult } from '@/components/message/pumpfun-launch';
+import { Card } from '@/components/ui/card';
+import { retrieveAgentKit } from '@/server/actions/ai';
 
 export const pumpfunTools = {
   launchToken: {

--- a/src/app/(user)/account/account-content.tsx
+++ b/src/app/(user)/account/account-content.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Card, CardContent } from '@/components/ui/card';
+import { useRouter } from 'next/navigation';
+
 import {
   Discord,
   OAuthTokens,
@@ -11,25 +11,27 @@ import {
   useOAuthTokens,
   usePrivy,
 } from '@privy-io/react-auth';
+import { useSolanaWallets } from '@privy-io/react-auth/solana';
+
+import { WalletCard } from '@/components/dashboard/wallet-card';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { CopyableText } from '@/components/ui/copyable-text';
+import { Label } from '@/components/ui/label';
+import { Separator } from '@/components/ui/separator';
+import { useUser } from '@/hooks/use-user';
+import { useEmbeddedWallets } from '@/hooks/use-wallets';
+import { cn } from '@/lib/utils';
 import {
   formatPrivyId,
   formatUserCreationDate,
   formatWalletAddress,
 } from '@/lib/utils/format';
 import { getUserID, grantDiscordRole } from '@/lib/utils/grant-discord-role';
-
-import { Button } from '@/components/ui/button';
-import { CopyableText } from '@/components/ui/copyable-text';
 import { EmbeddedWallet } from '@/types/db';
-import { Label } from '@/components/ui/label';
+
 import { LoadingStateSkeleton } from './loading-skeleton';
-import { Separator } from '@/components/ui/separator';
-import { WalletCard } from '@/components/dashboard/wallet-card';
-import { cn } from '@/lib/utils';
-import { useEmbeddedWallets } from '@/hooks/use-wallets';
-import { useRouter } from 'next/navigation';
-import { useSolanaWallets } from '@privy-io/react-auth/solana';
-import { useUser } from '@/hooks/use-user';
 
 export function AccountContent() {
   const router = useRouter();

--- a/src/app/(user)/chat/[id]/chat-interface.tsx
+++ b/src/app/(user)/chat/[id]/chat-interface.tsx
@@ -24,8 +24,8 @@ import usePolling from '@/hooks/use-polling';
 import { useWalletPortfolio } from '@/hooks/use-wallet-portfolio';
 import { uploadImage } from '@/lib/upload';
 import { cn, throttle } from '@/lib/utils';
-import { type ToolActionResult, ToolUpdate } from '@/types/util';
 import { convertToUIMessages } from '@/lib/utils/ai';
+import { type ToolActionResult, ToolUpdate } from '@/types/util';
 
 // Types
 interface UploadingImage extends Attachment {

--- a/src/app/(user)/faq/page.tsx
+++ b/src/app/(user)/faq/page.tsx
@@ -44,19 +44,19 @@ const faqItems: FaqItem[] = [
       </div>
     ),
   },
-   {
+  {
     id: 'item-3',
     question: 'How can I become EAP Verified in Discord?',
     answer: (
       <div className="space-y-4">
         <span>
-          On the bottom left, tap your wallet, then tap `Account`. Next, 
-          you should see a `Connect` button next to Discord. Tap on that 
-          and connect to the Discord server. 
-          <br/>
-          Once that is copmleted, you should now be `EAP VERIFIED` and see 
-          custom Discord channels for EAP users. Your name will also be 
-          color differentiated from other users. 
+          On the bottom left, tap your wallet, then tap `Account`. Next, you
+          should see a `Connect` button next to Discord. Tap on that and connect
+          to the Discord server.
+          <br />
+          Once that is copmleted, you should now be `EAP VERIFIED` and see
+          custom Discord channels for EAP users. Your name will also be color
+          differentiated from other users.
         </span>
       </div>
     ),

--- a/src/app/api/actions/[id]/route.ts
+++ b/src/app/api/actions/[id]/route.ts
@@ -3,9 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { verifyUser } from '@/server/actions/user';
 import { dbDeleteAction, dbUpdateAction } from '@/server/db/queries';
 
-export async function DELETE(
-  req: NextRequest,
-) {
+export async function DELETE(req: NextRequest) {
   try {
     const session = await verifyUser();
     const userId = session?.data?.data?.id;
@@ -13,10 +11,7 @@ export async function DELETE(
     const id = req.nextUrl.pathname.split('/').pop();
 
     if (!id) {
-      return NextResponse.json(
-        { error: 'Missing action ID' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Missing action ID' }, { status: 400 });
     }
 
     if (!userId) {
@@ -24,11 +19,11 @@ export async function DELETE(
     }
 
     const result = await dbDeleteAction({ id, userId });
-    
+
     if (!result) {
       return NextResponse.json(
         { error: 'Failed to delete action' },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -42,9 +37,7 @@ export async function DELETE(
   }
 }
 
-export async function PATCH(
-  req: NextRequest,
-) {
+export async function PATCH(req: NextRequest) {
   try {
     const session = await verifyUser();
     const userId = session?.data?.data?.id;
@@ -52,10 +45,7 @@ export async function PATCH(
     const id = req.nextUrl.pathname.split('/').pop();
 
     if (!id) {
-      return NextResponse.json(
-        { error: 'Missing action ID' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Missing action ID' }, { status: 400 });
     }
 
     if (!userId) {
@@ -64,17 +54,17 @@ export async function PATCH(
 
     const data = await req.json();
     const result = await dbUpdateAction({ id, userId, data });
-    
+
     if (!result) {
       return NextResponse.json(
         { error: 'Failed to update action' },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    return NextResponse.json({ 
-      success: true, 
-      data: result 
+    return NextResponse.json({
+      success: true,
+      data: result,
     });
   } catch (error) {
     console.error('Error updating action:', error);
@@ -83,4 +73,4 @@ export async function PATCH(
       { status: 500 },
     );
   }
-} 
+}

--- a/src/app/api/actions/route.ts
+++ b/src/app/api/actions/route.ts
@@ -21,4 +21,4 @@ export async function GET(req: NextRequest) {
       { status: 500 },
     );
   }
-} 
+}

--- a/src/app/api/chat/[conversationId]/route.ts
+++ b/src/app/api/chat/[conversationId]/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { verifyUser } from '@/server/actions/user';
+import { dbGetConversation } from '@/server/db/queries';
 
-import {
-  dbGetConversation,
-} from '@/server/db/queries';
-
-export async function GET(req: NextRequest, { params }: { params: Promise<{ conversationId: string }> }) {
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ conversationId: string }> },
+) {
   const session = await verifyUser();
   const userId = session?.data?.data?.id;
   const publicKey = session?.data?.data?.publicKey;
@@ -23,19 +23,30 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ conv
   const { conversationId } = await params;
 
   if (!conversationId) {
-    return NextResponse.json({ error: 'Missing conversationId' }, { status: 401 });
+    return NextResponse.json(
+      { error: 'Missing conversationId' },
+      { status: 401 },
+    );
   }
 
   try {
-    const conversation = await dbGetConversation({ conversationId, includeMessages: true });
+    const conversation = await dbGetConversation({
+      conversationId,
+      includeMessages: true,
+    });
 
     if (!conversation) {
-      return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+      return NextResponse.json(
+        { error: 'Conversation not found' },
+        { status: 404 },
+      );
     }
 
     return NextResponse.json(conversation);
   } catch (error) {
-    console.error(`[chat/[conversationId]/route] Error fetching conversation: ${error}`);
+    console.error(
+      `[chat/[conversationId]/route] Error fetching conversation: ${error}`,
+    );
     return NextResponse.json(
       { error: 'Internal Server Error' },
       { status: 500 },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,15 @@
 'use client';
 
+import { useRef, useState } from 'react';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import { useLogin } from '@privy-io/react-auth';
+import { GitHubLogoIcon } from '@radix-ui/react-icons';
+import { RiTwitterXFill } from '@remixicon/react';
+import { motion, useScroll, useTransform } from 'framer-motion';
 import {
   ActivityIcon,
   BookOpenIcon,
@@ -8,26 +18,18 @@ import {
   ShieldIcon,
   ZapIcon,
 } from 'lucide-react';
-import { BentoCard, BentoGrid } from '@/components/ui/bento-grid';
-import { motion, useScroll, useTransform } from 'framer-motion';
-import { useRef, useState } from 'react';
 
+import { Brand } from '@/components/logo';
 import { AiParticlesBackground } from '@/components/ui/ai-particles-background';
 import AnimatedShinyText from '@/components/ui/animated-shiny-text';
+import { BentoCard, BentoGrid } from '@/components/ui/bento-grid';
 import BlurFade from '@/components/ui/blur-fade';
 import { BorderBeam } from '@/components/ui/border-beam';
-import { Brand } from '@/components/logo';
 import { Button } from '@/components/ui/button';
-import { GitHubLogoIcon } from '@radix-ui/react-icons';
-import Image from 'next/image';
 import { IntegrationsBackground } from '@/components/ui/integrations-background';
-import Link from 'next/link';
 import Marquee from '@/components/ui/marquee';
 import { RainbowButton } from '@/components/ui/rainbow-button';
-import { RiTwitterXFill } from '@remixicon/react';
 import { cn } from '@/lib/utils';
-import { useLogin } from '@privy-io/react-auth';
-import { useRouter } from 'next/navigation';
 
 const navItems = [
   { label: 'Github', href: 'https://git.new/neur', icon: GitHubLogoIcon },

--- a/src/components/action-emitter.tsx
+++ b/src/components/action-emitter.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+
 import { EVENTS } from '@/lib/events';
 
 interface ActionEmitterProps {
@@ -10,10 +11,13 @@ interface ActionEmitterProps {
 export function ActionEmitter({ actionId }: ActionEmitterProps) {
   useEffect(() => {
     if (actionId) {
-      console.log('[ActionEmitter] Emitting action created event for:', actionId);
+      console.log(
+        '[ActionEmitter] Emitting action created event for:',
+        actionId,
+      );
       window.dispatchEvent(new CustomEvent(EVENTS.ACTION_CREATED));
     }
   }, [actionId]);
 
   return null;
-} 
+}

--- a/src/components/dashboard/app-sidebar-automations.tsx
+++ b/src/components/dashboard/app-sidebar-automations.tsx
@@ -6,11 +6,21 @@ import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 
 import { Action } from '@prisma/client';
-import { ChevronDown, Loader2, MoreHorizontal, PencilIcon, TrashIcon } from 'lucide-react';
+import {
+  ChevronDown,
+  Loader2,
+  MoreHorizontal,
+  PencilIcon,
+  TrashIcon,
+} from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 import {
   Dialog,
   DialogContent,
@@ -34,16 +44,18 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@/components/ui/sidebar';
-import { cn } from '@/lib/utils';
 import { useActions } from '@/hooks/use-actions';
 import { useUser } from '@/hooks/use-user';
-import { useActionStore } from '@/store/action-store';
 import { EVENTS } from '@/lib/events';
+import { cn } from '@/lib/utils';
 
 interface ActionMenuItemProps {
   action: Action;
   onDelete: (id: string) => Promise<{ success: boolean; error?: string }>;
-  onEdit: (id: string, data: Partial<Action>) => Promise<{ success: boolean; data?: Action; error?: string }>;
+  onEdit: (
+    id: string,
+    data: Partial<Action>,
+  ) => Promise<{ success: boolean; data?: Action; error?: string }>;
 }
 
 const ActionMenuItem = ({ action, onDelete, onEdit }: ActionMenuItemProps) => {
@@ -58,7 +70,7 @@ const ActionMenuItem = ({ action, onDelete, onEdit }: ActionMenuItemProps) => {
 
   const handleDelete = async () => {
     const loadingToast = toast.loading('Deleting automation...');
-    
+
     try {
       const result = await onDelete(action.id);
       if (result?.success) {
@@ -75,17 +87,17 @@ const ActionMenuItem = ({ action, onDelete, onEdit }: ActionMenuItemProps) => {
 
   const handleEdit = async () => {
     if (isLoading) return;
-    
+
     setIsLoading(true);
     const loadingToast = toast.loading('Updating automation...');
-    
+
     try {
       const result = await onEdit(action.id, {
         description: formData.description,
         frequency: formData.frequency || null,
         maxExecutions: formData.maxExecutions || null,
       });
-      
+
       if (result?.success) {
         toast.dismiss(loadingToast);
         toast.success('Automation updated');
@@ -128,11 +140,14 @@ const ActionMenuItem = ({ action, onDelete, onEdit }: ActionMenuItemProps) => {
         </DropdownMenu>
       </SidebarMenuItem>
 
-      <Dialog open={isEditing} onOpenChange={(open) => {
-        if (!isLoading) {
-          setIsEditing(open);
-        }
-      }}>
+      <Dialog
+        open={isEditing}
+        onOpenChange={(open) => {
+          if (!isLoading) {
+            setIsEditing(open);
+          }
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Edit Automation</DialogTitle>
@@ -143,7 +158,12 @@ const ActionMenuItem = ({ action, onDelete, onEdit }: ActionMenuItemProps) => {
               <Input
                 id="description"
                 value={formData.description}
-                onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    description: e.target.value,
+                  }))
+                }
                 placeholder="Enter message"
                 disabled={isLoading}
               />
@@ -154,7 +174,12 @@ const ActionMenuItem = ({ action, onDelete, onEdit }: ActionMenuItemProps) => {
                 id="frequency"
                 type="number"
                 value={formData.frequency}
-                onChange={(e) => setFormData(prev => ({ ...prev, frequency: parseInt(e.target.value) }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    frequency: parseInt(e.target.value),
+                  }))
+                }
                 placeholder="Enter frequency in seconds"
                 disabled={isLoading}
               />
@@ -165,7 +190,12 @@ const ActionMenuItem = ({ action, onDelete, onEdit }: ActionMenuItemProps) => {
                 id="maxExecutions"
                 type="number"
                 value={formData.maxExecutions}
-                onChange={(e) => setFormData(prev => ({ ...prev, maxExecutions: parseInt(e.target.value) }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    maxExecutions: parseInt(e.target.value),
+                  }))
+                }
                 placeholder="Enter max executions"
                 disabled={isLoading}
               />
@@ -198,27 +228,35 @@ const ActionMenuItem = ({ action, onDelete, onEdit }: ActionMenuItemProps) => {
 export const AppSidebarAutomations = () => {
   const pathname = usePathname();
   const { isLoading: isUserLoading, user } = useUser();
-  const { actions, isLoading: isActionsLoading, error, mutate: refreshActions } = useActions(user?.id);
+  const {
+    actions,
+    isLoading: isActionsLoading,
+    error,
+    mutate: refreshActions,
+  } = useActions(user?.id);
   const [isOpen, setIsOpen] = useState(true);
 
   // Listen for action creation events
-  useEffect(() => {
-    console.log('[Sidebar] Setting up action creation listener');
-    
-    const handleActionCreated = async () => {
-      console.log('[Sidebar] Action created event received');
-      try {
-        await refreshActions();
-        console.log('[Sidebar] Actions refreshed successfully');
-      } catch (error) {
-        console.error('[Sidebar] Error refreshing actions:', error);
-      }
-    };
+  const handleActionMutation = async () => {
+    console.log('[Sidebar] Event received');
+    try {
+      await refreshActions();
+      console.log('[Sidebar] Actions refreshed successfully');
+    } catch (error) {
+      console.error('[Sidebar] Error refreshing actions:', error);
+    }
+  };
 
-    window.addEventListener(EVENTS.ACTION_CREATED, handleActionCreated);
+  useEffect(() => {
+    console.log('[Sidebar] Setting up event listeners');
+
+    window.addEventListener(EVENTS.ACTION_CREATED, handleActionMutation);
+    window.addEventListener(EVENTS.ACTION_REFRESH, handleActionMutation);
+
     return () => {
-      console.log('[Sidebar] Cleaning up action creation listener');
-      window.removeEventListener(EVENTS.ACTION_CREATED, handleActionCreated);
+      console.log('[Sidebar] Cleaning up event listeners');
+      window.removeEventListener(EVENTS.ACTION_CREATED, handleActionMutation);
+      window.removeEventListener(EVENTS.ACTION_REFRESH, handleActionMutation);
     };
   }, [refreshActions]);
 
@@ -229,8 +267,8 @@ export const AppSidebarAutomations = () => {
 
   const handleDelete = async (id: string) => {
     try {
-      const response = await fetch(`/api/actions/${id}`, { 
-        method: 'DELETE' 
+      const response = await fetch(`/api/actions/${id}`, {
+        method: 'DELETE',
       });
 
       const data = await response.json();
@@ -284,7 +322,9 @@ export const AppSidebarAutomations = () => {
     return (
       <SidebarGroup>
         <SidebarGroupLabel>Automations</SidebarGroupLabel>
-        <p className="ml-2 text-xs text-destructive">Error loading automations</p>
+        <p className="ml-2 text-xs text-destructive">
+          Error loading automations
+        </p>
       </SidebarGroup>
     );
   }
@@ -296,10 +336,12 @@ export const AppSidebarAutomations = () => {
           <SidebarGroupLabel>Automations</SidebarGroupLabel>
           <CollapsibleTrigger asChild>
             <Button variant="ghost" size="sm" className="h-6 w-6 p-0">
-              <ChevronDown className={cn(
-                "h-4 w-4 transition-transform duration-200",
-                isOpen ? "" : "-rotate-90"
-              )} />
+              <ChevronDown
+                className={cn(
+                  'h-4 w-4 transition-transform duration-200',
+                  isOpen ? '' : '-rotate-90',
+                )}
+              />
             </Button>
           </CollapsibleTrigger>
         </div>
@@ -310,7 +352,9 @@ export const AppSidebarAutomations = () => {
                 <Loader2 className="mt-4 h-4 w-4 animate-spin" />
               </div>
             ) : !actions?.length ? (
-              <p className="ml-2 text-xs text-muted-foreground">No automations</p>
+              <p className="ml-2 text-xs text-muted-foreground">
+                No automations
+              </p>
             ) : (
               <SidebarMenu>
                 {actions.map((action) => (
@@ -328,4 +372,4 @@ export const AppSidebarAutomations = () => {
       </Collapsible>
     </SidebarGroup>
   );
-}; 
+};

--- a/src/components/dashboard/app-sidebar-conversations.tsx
+++ b/src/components/dashboard/app-sidebar-conversations.tsx
@@ -6,10 +6,21 @@ import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 
 import { Conversation } from '@prisma/client';
-import { Loader2, MoreHorizontal, PencilIcon, TrashIcon, ChevronDown } from 'lucide-react';
+import {
+  ChevronDown,
+  Loader2,
+  MoreHorizontal,
+  PencilIcon,
+  TrashIcon,
+} from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 import {
   Dialog,
   DialogContent,
@@ -30,6 +41,8 @@ import {
 } from '@/components/ui/sidebar';
 import { useConversations } from '@/hooks/use-conversations';
 import { useUser } from '@/hooks/use-user';
+import { EVENTS } from '@/lib/events';
+import { cn } from '@/lib/utils';
 
 import {
   SidebarGroup,
@@ -37,8 +50,6 @@ import {
   SidebarGroupLabel,
   SidebarMenu,
 } from '../ui/sidebar';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
-import { cn } from '@/lib/utils';
 
 interface ConversationMenuItemProps {
   id: string;
@@ -95,6 +106,9 @@ const ConversationMenuItem = ({
       // Navigate and refresh after successful deletion
       router.replace('/home');
       router.refresh();
+
+      // Emit the event to refresh actions
+      window.dispatchEvent(new CustomEvent(EVENTS.ACTION_REFRESH));
     } catch (error) {
       console.error('Error deleting conversation:', error);
       toast.error('Failed to delete conversation');
@@ -177,7 +191,7 @@ export const AppSidebarConversations = () => {
     setActiveId,
     refreshConversations,
   } = useConversations(user?.id);
-  
+
   // Add state for collapsible
   const [isOpen, setIsOpen] = useState(true);
 
@@ -207,10 +221,12 @@ export const AppSidebarConversations = () => {
           <SidebarGroupLabel>Conversations</SidebarGroupLabel>
           <CollapsibleTrigger asChild>
             <Button variant="ghost" size="sm" className="h-6 w-6 p-0">
-              <ChevronDown className={cn(
-                "h-4 w-4 transition-transform duration-200",
-                isOpen ? "" : "-rotate-90"
-              )} />
+              <ChevronDown
+                className={cn(
+                  'h-4 w-4 transition-transform duration-200',
+                  isOpen ? '' : '-rotate-90',
+                )}
+              />
             </Button>
           </CollapsibleTrigger>
         </div>
@@ -221,7 +237,9 @@ export const AppSidebarConversations = () => {
                 <Loader2 className="mt-4 h-4 w-4 animate-spin" />
               </div>
             ) : !conversations?.length ? (
-              <p className="ml-2 text-xs text-muted-foreground">No conversations</p>
+              <p className="ml-2 text-xs text-muted-foreground">
+                No conversations
+              </p>
             ) : (
               <SidebarMenu>
                 {conversations.map((conversation: Conversation) => (

--- a/src/components/dashboard/app-sidebar.tsx
+++ b/src/components/dashboard/app-sidebar.tsx
@@ -20,9 +20,9 @@ import {
 } from '@/components/ui/sidebar';
 import { APP_VERSION, IS_BETA } from '@/lib/constants';
 
+import { AppSidebarAutomations } from './app-sidebar-automations';
 import { AppSidebarConversations } from './app-sidebar-conversations';
 import { AppSidebarUser } from './app-sidebar-user';
-import { AppSidebarAutomations } from './app-sidebar-automations';
 
 const AppSidebarHeader = () => {
   return (

--- a/src/components/message/pumpfun-launch.tsx
+++ b/src/components/message/pumpfun-launch.tsx
@@ -1,18 +1,20 @@
 'use client';
 
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useEffect, useState } from 'react';
+
+import Image from 'next/image';
+
 import { Check, Copy, ExternalLink } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { useEffect, useState } from 'react';
-
-import { Button } from '@/components/ui/button';
-import Image from 'next/image';
-import { Skeleton } from '@/components/ui/skeleton';
 
 interface TokenMetadata {
   name: string;

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,16 +1,13 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+import * as React from 'react';
 
-const Collapsible = CollapsiblePrimitive.Root
+import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
 
-const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
+const Collapsible = CollapsiblePrimitive.Root;
 
-const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
 
-export {
-  Collapsible,
-  CollapsibleTrigger,
-  CollapsibleContent,
-} 
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/src/hooks/use-actions.ts
+++ b/src/hooks/use-actions.ts
@@ -1,11 +1,15 @@
 'use client';
 
+import { Action } from '@prisma/client';
 import useSWR from 'swr';
 
-import { Action } from '@prisma/client';
-
 export function useActions(userId?: string) {
-  const { data: actions, isLoading, error, mutate } = useSWR<Action[]>(
+  const {
+    data: actions,
+    isLoading,
+    error,
+    mutate,
+  } = useSWR<Action[]>(
     userId ? '/api/actions' : null,
     async (url) => {
       console.log('[Actions Hook] Fetching actions for user:', userId);
@@ -16,7 +20,7 @@ export function useActions(userId?: string) {
     },
     {
       revalidateOnFocus: false,
-    }
+    },
   );
 
   if (error) {
@@ -30,9 +34,3 @@ export function useActions(userId?: string) {
     mutate,
   };
 }
-
-// Add this export to allow other components to trigger a refresh
-export const refreshActions = () => {
-  const event = new CustomEvent('refresh-actions');
-  window.dispatchEvent(event);
-}; 

--- a/src/hooks/use-user.ts
+++ b/src/hooks/use-user.ts
@@ -1,13 +1,15 @@
 'use client';
 
-import { NeurUser, PrismaUser, PrivyUser } from '@/types/db';
-import { PrivyInterface, usePrivy } from '@privy-io/react-auth';
 import { useCallback, useEffect, useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { PrivyInterface, usePrivy } from '@privy-io/react-auth';
+import useSWR from 'swr';
 
 import { debugLog } from '@/lib/debug';
 import { getUserData } from '@/server/actions/user';
-import { useRouter } from 'next/navigation';
-import useSWR from 'swr';
+import { NeurUser, PrismaUser, PrivyUser } from '@/types/db';
 
 /**
  * Extended interface for NeurUser that includes Privy functionality

--- a/src/hooks/use-wallets.ts
+++ b/src/hooks/use-wallets.ts
@@ -1,7 +1,8 @@
 'use client';
 
-import { syncEmbeddedWallets } from '@/server/actions/user';
 import useSWR from 'swr';
+
+import { syncEmbeddedWallets } from '@/server/actions/user';
 
 export function useEmbeddedWallets() {
   return useSWR('embeddedWallets', async () => {

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,9 +1,4 @@
 export const EVENTS = {
   ACTION_CREATED: 'action-created',
+  ACTION_REFRESH: 'action-refresh',
 } as const;
-
-export function emitActionCreated() {
-  if (typeof window !== 'undefined') {
-    window.dispatchEvent(new CustomEvent(EVENTS.ACTION_CREATED));
-  }
-} 

--- a/src/server/actions/action.ts
+++ b/src/server/actions/action.ts
@@ -1,18 +1,18 @@
 import { CoreTool, NoSuchToolError, generateObject, generateText } from 'ai';
-import { dbCreateMessages, dbGetConversation } from '@/server/db/queries';
+import _ from 'lodash';
+import moment from 'moment';
+import { z } from 'zod';
+
 import {
   defaultModel,
   defaultSystemPrompt,
   defaultTools,
 } from '@/ai/providers';
-
-import { ActionWithUser } from '@/types/db';
-import _ from 'lodash';
-import moment from 'moment';
 import prisma from '@/lib/prisma';
-import { retrieveAgentKit } from '@/server/actions/ai';
 import { sanitizeResponseMessages } from '@/lib/utils/ai';
-import { z } from 'zod';
+import { retrieveAgentKit } from '@/server/actions/ai';
+import { dbCreateMessages, dbGetConversation } from '@/server/db/queries';
+import { ActionWithUser } from '@/types/db';
 
 const ACTION_PAUSE_THRESHOLD = 3;
 

--- a/src/server/actions/charts.ts
+++ b/src/server/actions/charts.ts
@@ -12,7 +12,7 @@ const priceHistorySchema = z.object({
 });
 
 export const getTokenId = async (contractAddress: string): Promise<string> => {
-  if(!API_KEY){
+  if (!API_KEY) {
     throw new Error('API key not found');
   }
   const url = `${BASE_URL}/coins/solana/contract/${contractAddress}`;
@@ -34,10 +34,13 @@ export const getTokenId = async (contractAddress: string): Promise<string> => {
   return parsed.id;
 };
 
-export const getPriceHistory = async (tokenId: string, days: number = 7): Promise<{ time: string; value: number }[]> => {
-   if(!API_KEY){
+export const getPriceHistory = async (
+  tokenId: string,
+  days: number = 7,
+): Promise<{ time: string; value: number }[]> => {
+  if (!API_KEY) {
     throw new Error('API key not found');
-   }
+  }
   const url = `${BASE_URL}/coins/${tokenId}/market_chart?vs_currency=usd&days=${days}&precision=18`;
   const options = {
     method: 'GET',
@@ -54,5 +57,8 @@ export const getPriceHistory = async (tokenId: string, days: number = 7): Promis
 
   const data = await response.json();
   const parsed = priceHistorySchema.parse(data);
-  return parsed.prices.map(([time, value]) => ({ time: new Date(time).toLocaleString(), value }));
+  return parsed.prices.map(([time, value]) => ({
+    time: new Date(time).toLocaleString(),
+    value,
+  }));
 };

--- a/src/server/actions/telegram.ts
+++ b/src/server/actions/telegram.ts
@@ -114,10 +114,18 @@ export async function checkUserTelegramSetup(
 }
 
 export const verifyTelegramSetupAction = actionClient
-  .schema(z.object({ username: z.string().optional(), userId: z.string().optional() }))
+  .schema(
+    z.object({
+      username: z.string().optional(),
+      userId: z.string().optional(),
+    }),
+  )
   .action<ActionResponse<TelegramActionData>>(async ({ parsedInput }) => {
     try {
-      const setup = await checkUserTelegramSetup(parsedInput.username, parsedInput.userId);
+      const setup = await checkUserTelegramSetup(
+        parsedInput.username,
+        parsedInput.userId,
+      );
       if (!setup.success) {
         return {
           success: false,

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -13,7 +13,7 @@ import { NewAction } from '@/types/db';
  */
 export async function dbGetConversation({
   conversationId,
-  includeMessages
+  includeMessages,
 }: {
   conversationId: string;
   includeMessages?: boolean;

--- a/src/store/action-store.ts
+++ b/src/store/action-store.ts
@@ -9,7 +9,9 @@ interface ActionStore {
 
 export const useActionStore = create<ActionStore>((set) => ({
   actionCount: 0,
-  incrementCount: () => set((state) => ({ actionCount: state.actionCount + 1 })),
+  incrementCount: () =>
+    set((state) => ({ actionCount: state.actionCount + 1 })),
   refreshTrigger: 0,
-  triggerRefresh: () => set((state) => ({ refreshTrigger: state.refreshTrigger + 1 })),
-})); 
+  triggerRefresh: () =>
+    set((state) => ({ refreshTrigger: state.refreshTrigger + 1 })),
+}));


### PR DESCRIPTION
Automatically issue an API call to refresh the actions when deleting a conversation so the actions list gets updated in the sidebar when deleting a conversation.

Removed some unused code from the bounty implementation.

Also ran prettier since several files were out of sync with .prettierrc