### PR TITLE
[Fix] getLatestTokenProfiles not executing

### DIFF
--- a/src/ai/solana/dexscreener.tsx
+++ b/src/ai/solana/dexscreener.tsx
@@ -470,13 +470,8 @@ export const dexscreenerTools = {
     parameters: z.object({
       placeholder: z.string().optional(),
     }),
-    execute: async ({ placeholder }: { placeholder: string }) => {
-      console.log(
-        '[DexScreener] Starting getLatestTokenProfiles execution',
-        placeholder,
-      );
+    execute: async () => {
       try {
-        console.log('[DexScreener] Fetching from token-profiles API');
         const response = await fetch(
           'https://api.dexscreener.com/token-profiles/latest/v1',
           {
@@ -484,24 +479,13 @@ export const dexscreenerTools = {
           },
         );
 
-        console.log('[DexScreener] API Response status:', response.status);
         if (!response.ok) {
-          console.error(
-            '[DexScreener] API Response error:',
-            response.statusText,
-          );
           throw new Error(
             `Failed to fetch token profiles: ${response.statusText}`,
           );
         }
 
-        console.log('[DexScreener] Parsing response as JSON');
         const profiles = (await response.json()) as DexScreenerTokenProfile[];
-        console.log('[DexScreener] Received profiles count:', profiles.length);
-        console.log(
-          '[DexScreener] Solana profiles count:',
-          profiles.filter((p) => p.chainId === 'solana').length,
-        );
 
         // Return up to first 10 profiles for Solana
         const solanaProfiles = profiles
@@ -513,16 +497,13 @@ export const dexscreenerTools = {
           data: solanaProfiles,
         };
       } catch (error) {
-        console.error('[DexScreener] Error in getLatestTokenProfiles:', error);
         throw new Error(
           `Failed to get token profiles: ${error instanceof Error ? error.message : 'Unknown error'}`,
         );
       }
     },
     render: (raw: unknown) => {
-      console.log('[DexScreener] Starting render of token profiles');
       const result = (raw as { data: DexScreenerTokenProfile[] }).data;
-      console.log('[DexScreener] Profiles to render:', result.length);
       return <TokenProfiles profiles={result} />;
     },
   },

--- a/src/ai/solana/dexscreener.tsx
+++ b/src/ai/solana/dexscreener.tsx
@@ -1,10 +1,16 @@
 import Image from 'next/image';
 
-import { ExternalLink } from 'lucide-react';
+import { ExternalLink, MoreHorizontal } from 'lucide-react';
 import { z } from 'zod';
 
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { capitalize } from '@/lib/utils/format';
 
 // Types
@@ -64,10 +70,13 @@ interface DexScreenerTokenProfile {
   header?: string;
   openGraph?: string;
   description?: string;
-  links?: {
-    type: string;
-    url: string;
-  }[];
+  links?: DexScreenerTokenProfileLink[];
+}
+
+interface DexScreenerTokenProfileLink {
+  type?: string;
+  label?: string;
+  url: string;
 }
 
 const OrdersResult = ({ orders }: { orders: DexScreenerOrder[] }) => {
@@ -249,64 +258,86 @@ const TokenProfiles = ({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="grid gap-2 sm:grid-cols-2">
       {solanaProfiles.map((profile, index) => (
-        <Card key={index} className="bg-muted/50 p-4">
-          <div className="flex gap-4">
-            {profile.icon && (
-              <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-xl">
-                <Image
-                  src={profile.icon}
-                  alt="Token Icon"
-                  className="object-cover"
-                  fill
-                  sizes="64px"
-                  onError={(e) => {
-                    // @ts-expect-error - Type 'string' is not assignable to type 'never'
-                    e.target.src = '/placeholder.png';
-                  }}
-                />
-              </div>
-            )}
-            <div className="flex-1 space-y-2">
-              <div className="flex items-center justify-between">
-                <h3 className="text-lg font-medium">
-                  <span className="font-mono text-sm text-muted-foreground">
-                    {profile.tokenAddress.slice(0, 4)}...
-                    {profile.tokenAddress.slice(-4)}
-                  </span>
-                </h3>
-                <a
-                  href={profile.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
-                >
-                  View on DexScreener
-                  <ExternalLink className="ml-1 h-3 w-3" />
-                </a>
-              </div>
-              {profile.description && (
-                <p className="whitespace-pre-line text-sm text-muted-foreground">
-                  {profile.description}
-                </p>
-              )}
-              {profile.links && profile.links.length > 0 && (
-                <div className="flex flex-wrap gap-2 pt-2">
-                  {profile.links.map((link, idx) => (
-                    <a
-                      key={idx}
-                      href={link.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center rounded-md bg-background px-2.5 py-1.5 text-sm capitalize hover:bg-accent"
-                    >
-                      {link.type}
-                      <ExternalLink className="ml-1 h-3 w-3" />
-                    </a>
-                  ))}
+        <Card key={index} className="bg-muted/50">
+          <div className="bg flex flex-col p-2">
+            <div className="flex gap-3">
+              {profile.icon && (
+                <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-xl">
+                  <Image
+                    src={profile.icon}
+                    alt="Token Icon"
+                    className="object-cover"
+                    fill
+                    sizes="64px"
+                    onError={(e) => {
+                      // @ts-expect-error - Type 'string' is not assignable to type 'never'
+                      e.target.src = '/placeholder.png';
+                    }}
+                  />
                 </div>
               )}
+              <div className="flex-1">
+                <div className="flex items-center justify-between">
+                  <code className="text-xs text-muted-foreground">
+                    {profile.tokenAddress.slice(0, 4)}...
+                    {profile.tokenAddress.slice(-4)}
+                  </code>
+                  <a
+                    href={profile.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center text-xs text-muted-foreground hover:text-foreground"
+                  >
+                    DexScreener
+                    <ExternalLink className="ml-1 h-3 w-3" />
+                  </a>
+                </div>
+                <div className="h-12 overflow-hidden py-1">
+                  {profile.description && (
+                    <p className="line-clamp-2 text-sm text-muted-foreground">
+                      {profile.description}
+                    </p>
+                  )}
+                </div>
+                {profile.links &&
+                  (profile.links.length <= 2 ? (
+                    <div className="flex flex-wrap gap-1.5">
+                      {profile.links.map((link, idx) => (
+                        <LinkChip key={idx} link={link} />
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="flex flex-wrap gap-1.5 overflow-hidden">
+                      <LinkChip link={profile.links[0]} />
+                      <TooltipProvider delayDuration={0}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="inline-flex cursor-default items-center rounded-md bg-background px-1.5 py-0.5 text-xs">
+                              +{profile.links.length - 1} more
+                              <MoreHorizontal className="ml-1 h-3 w-3" />
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent className="flex flex-col gap-1 p-2">
+                            {profile.links.slice(1).map((link, idx) => (
+                              <a
+                                key={idx}
+                                href={link.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center text-xs capitalize hover:text-accent"
+                              >
+                                {getLinkText(link)}
+                                <ExternalLink className="ml-1 h-2.5 w-2.5" />
+                              </a>
+                            ))}
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </div>
+                  ))}
+              </div>
             </div>
           </div>
         </Card>
@@ -314,6 +345,25 @@ const TokenProfiles = ({
     </div>
   );
 };
+
+const LinkChip = ({ link }: { link: DexScreenerTokenProfileLink }) => (
+  <a
+    href={link.url}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center rounded-md bg-background px-1.5 py-0.5 text-xs capitalize hover:bg-accent"
+  >
+    {getLinkText(link)}
+    <ExternalLink className="ml-1 h-2.5 w-2.5" />
+  </a>
+);
+
+const getLinkText = (link: DexScreenerTokenProfileLink) =>
+  link.type
+    ? capitalize(link.type)
+    : link.label
+      ? capitalize(link.label)
+      : 'Link';
 
 export const dexscreenerTools = {
   getTokenOrders: {
@@ -421,7 +471,10 @@ export const dexscreenerTools = {
       placeholder: z.string().optional(),
     }),
     execute: async ({ placeholder }: { placeholder: string }) => {
-      console.log('[DexScreener] Starting getLatestTokenProfiles execution', placeholder);
+      console.log(
+        '[DexScreener] Starting getLatestTokenProfiles execution',
+        placeholder,
+      );
       try {
         console.log('[DexScreener] Fetching from token-profiles API');
         const response = await fetch(

--- a/src/ai/solana/dexscreener.tsx
+++ b/src/ai/solana/dexscreener.tsx
@@ -417,9 +417,11 @@ export const dexscreenerTools = {
     displayName: '🌟 Latest Token Profiles',
     description:
       'Get the latest token profiles from DexScreener, focusing on Solana tokens. This shows tokens with verified profiles including their descriptions, social links, and branding assets.',
-    parameters: z.object({}),
-    execute: async () => {
-      console.log('[DexScreener] Starting getLatestTokenProfiles execution');
+    parameters: z.object({
+      placeholder: z.string().optional(),
+    }),
+    execute: async ({ placeholder }: { placeholder: string }) => {
+      console.log('[DexScreener] Starting getLatestTokenProfiles execution', placeholder);
       try {
         console.log('[DexScreener] Fetching from token-profiles API');
         const response = await fetch(
@@ -448,9 +450,14 @@ export const dexscreenerTools = {
           profiles.filter((p) => p.chainId === 'solana').length,
         );
 
+        // Return up to first 10 profiles for Solana
+        const solanaProfiles = profiles
+          .filter((p) => p.chainId === 'solana')
+          .slice(0, 10);
+
         return {
           suppressFollowUp: true,
-          data: profiles,
+          data: solanaProfiles,
         };
       } catch (error) {
         console.error('[DexScreener] Error in getLatestTokenProfiles:', error);

--- a/src/ai/solana/solana.tsx
+++ b/src/ai/solana/solana.tsx
@@ -345,7 +345,7 @@ export function TokenHoldersResult({
                     <TableCell className="max-w-xs px-4 py-4">
                       <div className="flex flex-col justify-center gap-1">
                         <div className="font-mono">
-                          <TooltipProvider>
+                          <TooltipProvider delayDuration={0}>
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <a

--- a/src/components/message/pumpfun-launch.tsx
+++ b/src/components/message/pumpfun-launch.tsx
@@ -65,7 +65,7 @@ function DetailItem({
     <div className="flex items-center justify-between gap-4 rounded-lg border bg-card/50 p-3">
       <div className="min-w-0 flex-1">
         <div className="text-sm font-medium text-muted-foreground">{label}</div>
-        <TooltipProvider>
+        <TooltipProvider delayDuration={0}>
           <Tooltip>
             <TooltipTrigger asChild>
               <div className="w-fit cursor-help font-mono text-sm">
@@ -79,7 +79,7 @@ function DetailItem({
         </TooltipProvider>
       </div>
       <div className="flex shrink-0 items-center gap-2">
-        <TooltipProvider>
+        <TooltipProvider delayDuration={0}>
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -99,7 +99,7 @@ function DetailItem({
           </Tooltip>
         </TooltipProvider>
         {showExternalLink && link && (
-          <TooltipProvider>
+          <TooltipProvider delayDuration={0}>
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button


### PR DESCRIPTION
`getLatestTokenProfiles` wasn't running because it was originally provided with an empty parameters schema, which it seems like streamText does not like.

Adding this works, but maybe we want to have a certain structure for anything else like this in the future so it doesn't interfere with what the model actually picks tool-wise.

```
parameters: z.object({
      placeholder: z.string().optional(),
}),
```

Trimmed to 10 elements since API was returning 30, which is a ton to display.

@beefmuldoon if you want to give this UI a new coat of paint you can work off of this change.

Can probably remove the console.log statements here, I want to start getting rid of those on the client.