### PR TITLE
Fix client error when navigating from account to home

### DIFF
--- a/src/components/floating-wallet.tsx
+++ b/src/components/floating-wallet.tsx
@@ -29,7 +29,7 @@ export function FloatingWallet({
   useEffect(() => {
     setMounted(true);
     // Preload all token images
-    if (data.tokens.length > 0) {
+    if (data.tokens?.length > 0) {
       Promise.all(
         data.tokens.map((token) => {
           if (!token.imageUrl) return Promise.resolve();


### PR DESCRIPTION
This fixes the error, but not sure why the data is getting here without being transformed by `transformToPortfolio`.

Data is structured like

```
{
  'fungibleTokens': ...
  'nonFungibleTokens': ...
}
```

`tokens` field does not exist when navigating in this manner