### PR TITLE
Dynamic action scheduling

### DIFF
--- a/prisma/migrations/20250120202224_add_action_starttime/migration.sql
+++ b/prisma/migrations/20250120202224_add_action_starttime/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "actions" ADD COLUMN     "startTime" TIMESTAMP(3);
+ALTER TABLE "actions" ADD COLUMN     "name"      VARCHAR(255);
+UPDATE "actions" SET name = description;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -105,6 +105,7 @@ model Action {
   stoppedBy      Int[] // Array of rule IDs required to stop this action
   frequency      Int? // Frequency in seconds (e.g., 3600 for 1 hour, 86400 for 1 day)
   maxExecutions  Int? // Times to execute before stopping
+  name           String?   @db.VarChar(255) // User defined name for the action
   description    String    @db.VarChar(255) // Human readable description of the action, or message to send to AI
   actionType     String    @db.VarChar(255) // Type of action (e.g., "call_function", "invoke_api")
   params         Json? // JSON object for action parameters (e.g., inputs for the function)
@@ -118,6 +119,7 @@ model Action {
   priority       Int       @default(0) // Priority level for execution, higher numbers execute first
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt
+  startTime      DateTime? // Time to start executing the action
 
   user         User         @relation(fields: [userId], references: [id])
   conversation Conversation @relation(fields: [conversationId], references: [id])

--- a/src/app/api/cron/minute/route.ts
+++ b/src/app/api/cron/minute/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: Request) {
     });
   }
 
-  // Quarter-hour cron job
+  // Minute cron job
   // Get all Actions that are not completed or paused
   const actions = await dbGetActions({
     triggered: true,
@@ -22,7 +22,7 @@ export async function GET(request: Request) {
 
   console.log(`[cron/action] Fetched ${actions.length} actions`);
 
-  // This job runs every 15 minutes, but we only need to process actions that are ready to be processed, based on their frequency
+  // This job runs every minute minute, but we only need to process actions that are ready to be processed, based on their frequency
   // Filter the actions to only include those that are ready to be processed based on their lastExecutedAt and frequency
   const now = new Date();
   const actionsToProcess = actions.filter((action) => {

--- a/src/components/dashboard/app-sidebar-automations.tsx
+++ b/src/components/dashboard/app-sidebar-automations.tsx
@@ -48,6 +48,7 @@ import { useActions } from '@/hooks/use-actions';
 import { useUser } from '@/hooks/use-user';
 import { EVENTS } from '@/lib/events';
 import { cn } from '@/lib/utils';
+import { NO_CONFIRMATION_MESSAGE } from '@/lib/constants';
 
 interface ActionMenuItemProps {
   action: Action;
@@ -62,10 +63,12 @@ const ActionMenuItem = ({ action, onDelete, onEdit }: ActionMenuItemProps) => {
   const router = useRouter();
   const [isEditing, setIsEditing] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+
   const [formData, setFormData] = useState({
-    description: action.description,
-    frequency: action.frequency || 0,
-    maxExecutions: action.maxExecutions || 0,
+    name: action.name || action.description,
+    description: action.description.replace(NO_CONFIRMATION_MESSAGE, ''),
+    frequency: action.frequency ?? null,
+    maxExecutions: action.maxExecutions ?? null,
   });
 
   const handleDelete = async () => {
@@ -93,9 +96,10 @@ const ActionMenuItem = ({ action, onDelete, onEdit }: ActionMenuItemProps) => {
 
     try {
       const result = await onEdit(action.id, {
-        description: formData.description,
-        frequency: formData.frequency || null,
-        maxExecutions: formData.maxExecutions || null,
+        name: formData.name,
+        description: formData.description + NO_CONFIRMATION_MESSAGE,
+        frequency: formData.frequency,
+        maxExecutions: formData.maxExecutions,
       });
 
       if (result?.success) {
@@ -118,7 +122,7 @@ const ActionMenuItem = ({ action, onDelete, onEdit }: ActionMenuItemProps) => {
       <SidebarMenuItem>
         <SidebarMenuButton asChild>
           <Link href={`/chat/${action.conversationId}`}>
-            <span>{action.description}</span>
+            <span>{action.name}</span>
           </Link>
         </SidebarMenuButton>
         <DropdownMenu>
@@ -154,6 +158,21 @@ const ActionMenuItem = ({ action, onDelete, onEdit }: ActionMenuItemProps) => {
           </DialogHeader>
           <div className="space-y-4 py-4">
             <div className="space-y-2">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                value={formData.name}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    name: e.target.value,
+                  }))
+                }
+                placeholder="Enter action name"
+                disabled={isLoading}
+              />
+            </div>
+            <div className="space-y-2">
               <Label htmlFor="description">Message</Label>
               <Input
                 id="description"
@@ -173,11 +192,11 @@ const ActionMenuItem = ({ action, onDelete, onEdit }: ActionMenuItemProps) => {
               <Input
                 id="frequency"
                 type="number"
-                value={formData.frequency}
+                value={formData.frequency ?? ''}
                 onChange={(e) =>
                   setFormData((prev) => ({
                     ...prev,
-                    frequency: parseInt(e.target.value),
+                    frequency: e.target.value ? parseInt(e.target.value, 10) : null, // Parse or null
                   }))
                 }
                 placeholder="Enter frequency in seconds"
@@ -189,11 +208,11 @@ const ActionMenuItem = ({ action, onDelete, onEdit }: ActionMenuItemProps) => {
               <Input
                 id="maxExecutions"
                 type="number"
-                value={formData.maxExecutions}
+                value={formData.maxExecutions ?? ''}
                 onChange={(e) =>
                   setFormData((prev) => ({
                     ...prev,
-                    maxExecutions: parseInt(e.target.value),
+                    maxExecutions: e.target.value ? parseInt(e.target.value, 10) : null, // Parse or null
                   }))
                 }
                 placeholder="Enter max executions"

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,3 +8,5 @@ export const RPC_URL =
   'https://api.mainnet-beta.solana.com';
 
 export const MAX_TOKEN_MESSAGES = 10;
+
+export const NO_CONFIRMATION_MESSAGE = ' (Does not require confirmation)';

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -221,9 +221,9 @@ export async function dbGetConversations({ userId }: { userId: string }) {
  * @returns {Promise<Action[]>} Array of actions
  */
 export async function dbGetActions({
-  triggered,
-  paused,
-  completed,
+  triggered = true,
+  paused = false,
+  completed = false,
 }: {
   triggered: boolean;
   paused: boolean;
@@ -235,6 +235,10 @@ export async function dbGetActions({
         triggered,
         paused,
         completed,
+        OR: [
+          { startTime: { lte: new Date() } },
+          { startTime: null }
+        ]
       },
       orderBy: { createdAt: 'desc' },
       include: { user: { include: { wallets: true } } },
@@ -401,6 +405,7 @@ export async function dbUpdateAction({
   try {
     // Validate and clean the data before update
     const validData = {
+      name: data.name,
       description: data.description,
       frequency: data.frequency === 0 ? null : data.frequency,
       maxExecutions: data.maxExecutions === 0 ? null : data.maxExecutions,

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "crons": [
     {
-      "path": "/api/cron/15-min",
-      "schedule": "*/15 * * * *"
+      "path": "/api/cron/minute",
+      "schedule": "* * * * *"
     }
   ]
 }


### PR DESCRIPTION
- Introduces new column on `actions` for `startTime`. If user specifies when to start the action this will be set, otherwise null. Cron updated to run every minute, and only search for actions that have been started.
- Adds `name` column on `actions` (defaulted to `description` for existing rows)
  - Separates name from description in action edit popup, so users can rename actions without affecting the message sent
- Fixes null handling in action edit popup for frequency and maxExecutions