### PR TITLE
Verify user before retrieving conversation

### DIFF
--- a/src/app/api/chat/[conversationId]/route.ts
+++ b/src/app/api/chat/[conversationId]/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { verifyUser } from '@/server/actions/user';
-import {
-  dbGetConversation,
-  dbGetConversationMessages,
-} from '@/server/db/queries';
+import { dbGetConversationMessages } from '@/server/db/queries';
 
 export async function GET(
   req: NextRequest,

--- a/src/server/actions/action.ts
+++ b/src/server/actions/action.ts
@@ -43,6 +43,7 @@ export async function processAction(action: ActionWithUser) {
   try {
     const conversation = await dbGetConversation({
       conversationId: action.conversationId,
+      userId: action.userId,
       isServer: true,
     });
 

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -15,10 +15,12 @@ import { NewAction } from '@/types/db';
  */
 export async function dbGetConversation({
   conversationId,
+  userId,
   includeMessages,
   isServer,
 }: {
   conversationId: string;
+  userId: string;
   includeMessages?: boolean;
   isServer?: boolean;
 }) {
@@ -26,13 +28,13 @@ export async function dbGetConversation({
     // Mark conversation as read if user is fetching
     if (!isServer) {
       return await prisma.conversation.update({
-        where: { id: conversationId },
+        where: { id: conversationId, userId },
         data: { lastReadAt: new Date() },
         include: includeMessages ? { messages: true } : undefined,
       });
     } else {
       return await prisma.conversation.findUnique({
-        where: { id: conversationId },
+        where: { id: conversationId, userId },
         include: includeMessages ? { messages: true } : undefined,
       });
     }


### PR DESCRIPTION
Saves some db bandwidth in a user requested someone elses conversation. This is assuming all conversations are private, which they are now