### PR TITLE
feat: allow users delete empty accounts 

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-accordion": "^1.2.2",
     "@radix-ui/react-alert-dialog": "^1.1.4",
     "@radix-ui/react-avatar": "^1.1.2",
+    "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-collapsible": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@radix-ui/react-avatar':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-checkbox':
+        specifier: ^1.1.4
+        version: 1.1.4(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-collapsible':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1469,6 +1472,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-checkbox@1.1.4':
+    resolution: {integrity: sha512-wP0CPAHq+P5I4INKe3hJrIa1WoNqqrejzW+zoU0rOvo1b9gDEJJFl2rYfO1PYJUQCc2H1WZxIJmyv9BS8i5fLw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-collapsible@1.1.2':
     resolution: {integrity: sha512-PliMB63vxz7vggcyq0IxNYk8vGDrLXVWw4+W4B8YnwI1s18x7YZYqlG9PLX7XxAJUi0g2DxP4XKJMFHh/iVh9A==}
     peerDependencies:
@@ -1701,6 +1717,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.0.2':
+    resolution: {integrity: sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-progress@1.1.1':
     resolution: {integrity: sha512-6diOawA84f/eMxFHcWut0aE1C2kyE9dOyCTQOMRR2C/qPiXz/X0SaiA/RLbapQaXUCmy0/hLMf9meSccD1N0pA==}
     peerDependencies:
@@ -1781,6 +1810,15 @@ packages:
 
   '@radix-ui/react-slot@1.1.1':
     resolution: {integrity: sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.1.2':
+    resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -9089,6 +9127,22 @@ snapshots:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
+  '@radix-ui/react-checkbox@1.1.4(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@19.0.7)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.7
+      '@types/react-dom': 19.0.3(@types/react@19.0.7)
+
   '@radix-ui/react-collapsible@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -9332,6 +9386,15 @@ snapshots:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
+  '@radix-ui/react-primitive@2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.2(@types/react@19.0.7)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.7
+      '@types/react-dom': 19.0.3(@types/react@19.0.7)
+
   '@radix-ui/react-progress@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-context': 1.1.1(@types/react@19.0.7)(react@19.0.0)
@@ -9433,6 +9496,13 @@ snapshots:
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
   '@radix-ui/react-slot@1.1.1(@types/react@19.0.7)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.7
+
+  '@radix-ui/react-slot@1.1.2(@types/react@19.0.7)(react@19.0.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.0)
       react: 19.0.0

--- a/src/app/(user)/account/account-content.tsx
+++ b/src/app/(user)/account/account-content.tsx
@@ -280,9 +280,12 @@ export function AccountContent() {
               Profile Information
             </h2>
             <DeleteAccountDialog
-              title="Delete Account"
-              content="Delete"
               displayPrompt={displayPrompt}
+              onCancel={() => setDisplayPrompt(false)}
+              onConfirm={() => {
+                // Delete account
+                console.log("delete account");
+              }}
             />
 
             <Card className="bg-sidebar">

--- a/src/app/(user)/account/delete-account-dialog.tsx
+++ b/src/app/(user)/account/delete-account-dialog.tsx
@@ -1,6 +1,8 @@
 import { Dispatch, SetStateAction } from 'react';
+import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Dialog,
   DialogContent,
@@ -9,30 +11,57 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
 
 interface DeletePromptDialogProps {
-  title: string;
-  content: string;
   displayPrompt: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
 }
 
 export const DeleteAccountDialog = ({
-  title,
-  content,
   displayPrompt,
-}: DeletePromptDialogProps) => (
-  <Dialog onOpenChange={() => {}} open={displayPrompt}>
-    <DialogContent className="sm:max-w-[650px]">
-      <DialogHeader>
-        <DialogTitle>Delete Account</DialogTitle>
-      </DialogHeader>
-      <div className="flex flex-col gap-4 py-4">
-        Delete Account
-        <div className="text-sm text-gray-500">Delete</div>
-      </div>
-      <DialogFooter>
-        <Button type="submit">Delete Account</Button>
-      </DialogFooter>
-    </DialogContent>
-  </Dialog>
-);
+  onCancel,
+  onConfirm,
+}: DeletePromptDialogProps) => {
+  const [ackChecked, setAckChecked] = useState(false);
+  return (
+    <Dialog onOpenChange={onCancel} open={displayPrompt}>
+      <DialogContent className="sm:max-w-[650px]">
+        <DialogHeader>
+          <DialogTitle>Delete Account Confirmation</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 text-sm text-gray-700">
+          <p>
+            This action is{' '}
+            <span className="font-semibold text-red-600">destructive</span> and{' '}
+            <span className="font-semibold">cannot be undone</span>.
+          </p>
+          <p>
+            Before proceeding, please ensure all your{' '}
+            <strong>embedded wallets are empty</strong>.
+          </p>
+          <p>
+            You are <strong>solely responsible</strong> for verifying your funds are safely
+            withdrawn before deleting your account.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox onCheckedChange={(checked) => setAckChecked(checked)} />
+          <Label
+            htmlFor="ack-checkbox"
+            className="cursor-pointer text-sm leading-snug"
+          >
+            I confirm that my wallets are empty and I understand this action is
+            irreversible.
+          </Label>
+        </div>
+        <DialogFooter>
+          <Button variant="destructive" disabled={!ackChecked} onClick={onConfirm}>
+            Delete Account
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/app/(user)/account/delete-account-dialog.tsx
+++ b/src/app/(user)/account/delete-account-dialog.tsx
@@ -15,12 +15,14 @@ import { Label } from '@/components/ui/label';
 
 interface DeletePromptDialogProps {
   displayPrompt: boolean;
+  eligibililty: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }
 
 export const DeleteAccountDialog = ({
   displayPrompt,
+  eligibililty,
   onCancel,
   onConfirm,
 }: DeletePromptDialogProps) => {
@@ -31,36 +33,76 @@ export const DeleteAccountDialog = ({
         <DialogHeader>
           <DialogTitle>Delete Account Confirmation</DialogTitle>
         </DialogHeader>
-        <div className="space-y-4 text-sm text-gray-700">
-          <p>
-            This action is{' '}
-            <span className="font-semibold text-red-600">destructive</span> and{' '}
-            <span className="font-semibold">cannot be undone</span>.
-          </p>
-          <p>
-            Before proceeding, please ensure all your{' '}
-            <strong>embedded wallets are empty</strong>.
-          </p>
-          <p>
-            You are <strong>solely responsible</strong> for verifying your funds are safely
-            withdrawn before deleting your account.
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Checkbox onCheckedChange={(checked) => setAckChecked(checked)} />
-          <Label
-            htmlFor="ack-checkbox"
-            className="cursor-pointer text-sm leading-snug"
-          >
-            I confirm that my wallets are empty and I understand this action is
-            irreversible.
-          </Label>
-        </div>
-        <DialogFooter>
-          <Button variant="destructive" disabled={!ackChecked} onClick={onConfirm}>
-            Delete Account
-          </Button>
-        </DialogFooter>
+        {eligibililty ? (
+          <>
+            <div className="space-y-4 text-sm text-gray-700">
+              <p>
+                This action is{' '}
+                <span className="font-semibold text-red-600">destructive</span>{' '}
+                and <span className="font-semibold">cannot be undone</span>.
+              </p>
+              <p>
+                Before proceeding, please ensure all your{' '}
+                <strong>embedded wallets are empty</strong>.
+              </p>
+              <p>
+                You are <strong>solely responsible</strong> for verifying your
+                funds are safely withdrawn before deleting your account.
+              </p>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="ack-checkbox"
+                onCheckedChange={(checked) => setAckChecked(checked)}
+              />
+              <Label
+                htmlFor="ack-checkbox"
+                className="cursor-pointer text-sm leading-snug"
+              >
+                I confirm that my wallets are empty and I understand this action
+                is irreversible.
+              </Label>
+            </div>
+
+            <DialogFooter>
+              <Button
+                variant="destructive"
+                disabled={!ackChecked}
+                onClick={onConfirm}
+              >
+                Delete Account
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <div className="space-y-4 text-sm text-gray-700">
+              <p>Your account cannot be deleted at this time.</p>
+              <p>
+                Either your{' '}
+                <strong>embedded wallet balance is not empty</strong>, or you
+                are currently participating in an{' '}
+                <strong>Early Access Program (EAP)</strong>.
+              </p>
+              <p>
+                Please reach out to our official Discord server for assistance.
+              </p>
+            </div>
+
+            <DialogFooter>
+              <Button asChild>
+                <a
+                  href="https://discord.neur.sh/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Contact Discord Support
+                </a>
+              </Button>
+            </DialogFooter>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/app/(user)/account/delete-account-dialog.tsx
+++ b/src/app/(user)/account/delete-account-dialog.tsx
@@ -1,0 +1,38 @@
+import { Dispatch, SetStateAction } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+
+interface DeletePromptDialogProps {
+  title: string;
+  content: string;
+  displayPrompt: boolean;
+}
+
+export const DeleteAccountDialog = ({
+  title,
+  content,
+  displayPrompt,
+}: DeletePromptDialogProps) => (
+  <Dialog onOpenChange={() => {}} open={displayPrompt}>
+    <DialogContent className="sm:max-w-[650px]">
+      <DialogHeader>
+        <DialogTitle>Delete Account</DialogTitle>
+      </DialogHeader>
+      <div className="flex flex-col gap-4 py-4">
+        Delete Account
+        <div className="text-sm text-gray-500">Delete</div>
+      </div>
+      <DialogFooter>
+        <Button type="submit">Delete Account</Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+);

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import * as React from 'react';
+
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
+import { CheckIcon } from '@radix-ui/react-icons';
+
+import { cn } from '@/lib/utils';
+
+
+interface CheckboxProps
+  // Include all the props that <CheckboxPrimitive.Root /> accepts, except the ref.
+  extends React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> {
+  onCheckedChange?: (checked: boolean) => void;
+}
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  CheckboxProps
+>(({ className, onCheckedChange, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      'peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow-sm data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+      className,
+    )}
+    onCheckedChange={(checked) => {
+      onCheckedChange?.(checked === true);
+    }}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+      <CheckIcon className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = 'Checkbox';
+
+export { Checkbox };

--- a/src/hooks/use-wallets.ts
+++ b/src/hooks/use-wallets.ts
@@ -2,7 +2,10 @@
 
 import useSWR from 'swr';
 
+import { searchWalletAssets } from '@/lib/solana/helius';
 import { syncEmbeddedWallets } from '@/server/actions/user';
+import { EmbeddedWallet } from '@/types/db';
+import { SOL_MINT } from '@/types/helius/portfolio';
 
 export function useEmbeddedWallets() {
   return useSWR('embeddedWallets', async () => {
@@ -14,4 +17,29 @@ export function useEmbeddedWallets() {
     // Return just the wallets array for convenience
     return result?.data?.data?.wallets;
   });
+}
+
+export async function getTotalWalletBalance(embeddedWallets: EmbeddedWallet[]): Promise<number> {
+  const balances = await Promise.all(
+    embeddedWallets.map(async (wallet) => {
+      try {
+        const walletPortfolio = await searchWalletAssets(wallet.publicKey);
+
+        const solBalanceInfo = walletPortfolio?.fungibleTokens?.find(
+          (t) => t.id === SOL_MINT,
+        );
+
+        const balance = solBalanceInfo
+          ? solBalanceInfo.token_info.balance /
+            10 ** solBalanceInfo.token_info.decimals
+          : 0;
+
+        return balance; // return a number
+      } catch (error) {
+        return 0;
+      }
+    }),
+  );
+  const total = balances.reduce((sum, cur) => sum + cur, 0);
+  return total;
 }

--- a/src/hooks/use-wallets.ts
+++ b/src/hooks/use-wallets.ts
@@ -11,17 +11,16 @@ async function getEmbeddedWalletBalance(embeddedWallet: EmbeddedWallet): Promise
   try {
     const walletPortfolio = await searchWalletAssets(embeddedWallet.publicKey);
 
-    // const solBalanceInfo = walletPortfolio?.fungibleTokens?.find(
-    //   (t) => t.id === SOL_MINT,
-    // );
+    const solBalanceInfo = walletPortfolio?.fungibleTokens?.find(
+      (t) => t.id === SOL_MINT,
+    );
 
-    // const balance = solBalanceInfo
-    //   ? solBalanceInfo.token_info.balance /
-    //     10 ** solBalanceInfo.token_info.decimals
-    //   : 0;
+    const balance = solBalanceInfo
+      ? solBalanceInfo.token_info.balance /
+        10 ** solBalanceInfo.token_info.decimals
+      : 0;
 
-    // return balance; // return a number
-    return 0;
+    return balance; 
   } catch (error) {
     return 0;
   }


### PR DESCRIPTION
Fixes https://github.com/NeurProjects/neur-app/issues/146 

Preconditions:
1. Checks total balance across all embedded wallets (legacy and privy wallets)
2. Checks if user is currently enrolled in EAP

If 1 or 2 is true, display panel that requests user to reach out to discord for deletion support. This is to protect us from users who accuses us of deleting their wallets with balances in them.


https://github.com/user-attachments/assets/898dcec1-1670-49f0-a719-5d2512bab8d4



If 1 and 2 are both false, the account is eligible for deletion. Nevertheless, we ask that the user tick an ack box to confirm they have done their own due diligence to ensure their embedded wallets are empty. 

Once that is done, the deletion will perform an atomic transaction where it will 

- delete all embedded wallets binded to the userId
- delete the user 
- delete the privy account associated with the user
- logout 
- display the relevant toast messages 


https://github.com/user-attachments/assets/3f8f0408-170b-4866-8b6f-b753c113e6ab


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced account management: Users with an empty account now see a delete option with a confirmation dialog, making it easier to remove an inactive account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->