### PR TITLE
Feat/add prompt filtering on homepage

### DIFF
--- a/src/app/(user)/home/home-content.tsx
+++ b/src/app/(user)/home/home-content.tsx
@@ -99,8 +99,10 @@ export function HomeContent() {
     // Unset current filter if selected again
     if (value === filter) {
       setFilter(DEFAULT_FILTER);
+      localStorage.setItem('savedPromptsFilterPreference', DEFAULT_FILTER);
     } else {
       setFilter(value);
+      localStorage.setItem('savedPromptsFilterPreference', value);
     }
     setPaginationIndex(0);
   }
@@ -124,6 +126,16 @@ export function HomeContent() {
 
     return promptsToSort;
   }, [filter, savedPrompts]);
+
+  function fetchFilterPreference() {
+    const savedFilter = localStorage.getItem('savedPromptsFilterPreference');
+    if (savedFilter) {
+      setFilter(savedFilter as FilterValue);
+    } else {
+      setFilter(DEFAULT_FILTER);
+      localStorage.setItem('savedPromptsFilterPreference', DEFAULT_FILTER);
+    }
+  }
 
   function sortPrompts(
     prompts: SavedPrompt[],
@@ -157,6 +169,7 @@ export function HomeContent() {
       setIsFetchingSavedPrompts(false);
     }
     fetchSavedPrompts();
+    fetchFilterPreference();
   }, []);
 
   const { messages, input, handleSubmit, setInput } = useChat({

--- a/src/app/(user)/saved-prompts/components/filter-dropdown.tsx
+++ b/src/app/(user)/saved-prompts/components/filter-dropdown.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-import { Check, Filter } from 'lucide-react';
+import { Check, ChevronDown, ChevronUp, Filter } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -22,6 +22,7 @@ import { cn } from '@/lib/utils';
 import { FilterOption, FilterValue } from '../types/prompt';
 
 interface FilterDropdownProps {
+  displayAtHomePage?: boolean;
   disabled: boolean;
   filter: FilterValue;
   filterOptions: FilterOption[];
@@ -29,6 +30,7 @@ interface FilterDropdownProps {
 }
 
 export function FilterDropdown({
+  displayAtHomePage = false,
   disabled,
   filter,
   filterOptions,
@@ -41,16 +43,28 @@ export function FilterDropdown({
       <PopoverTrigger asChild>
         <Button
           disabled={disabled}
-          variant="outline"
+          variant={displayAtHomePage ? 'ghost' : 'outline'}
           role="combobox"
           aria-expanded={open}
-          className="w-auto justify-between"
+          className={cn(
+            displayAtHomePage
+              ? 'px-1 pb-0 text-sm font-medium text-muted-foreground/80 hover:bg-transparent'
+              : 'w-auto justify-between',
+          )}
         >
           {
             filterOptions.find((filterOption) => filterOption.value === filter)
               ?.label
           }
-          <Filter className="opacity-50" />
+          {displayAtHomePage ? (
+            open ? (
+              <ChevronUp size={13} />
+            ) : (
+              <ChevronDown size={13} />
+            )
+          ) : (
+            <Filter className="opacity-50" />
+          )}
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[200px] p-0">

--- a/src/app/(user)/saved-prompts/page.tsx
+++ b/src/app/(user)/saved-prompts/page.tsx
@@ -9,6 +9,7 @@ import { toast } from 'sonner';
 
 import { Input } from '@/components/ui/input';
 import { useUser } from '@/hooks/use-user';
+import { filterOptions } from '@/lib/constants';
 import {
   createSavedPrompt,
   deleteSavedPrompt,
@@ -27,29 +28,6 @@ const EMPTY_ACTION: PromptAction = {
   action: null,
   id: null,
 };
-
-const filterOptions: FilterOption[] = [
-  {
-    value: 'recentlyUsed',
-    label: 'Recently Used',
-  },
-  {
-    value: 'editedRecently',
-    label: 'Edited Recently',
-  },
-  {
-    value: 'latest',
-    label: 'Newest First',
-  },
-  {
-    value: 'oldest',
-    label: 'Oldest First',
-  },
-  {
-    value: 'favorites',
-    label: 'Favorites',
-  },
-];
 
 export default function SavedPromptsPage() {
   /**
@@ -399,7 +377,7 @@ export default function SavedPromptsPage() {
                   </button>
                 </div>
               </div>
-              <div className="text-xs text-muted-foreground/80">
+              <div className="truncate text-xs text-muted-foreground/80">
                 {prompt.content.trim().slice(0, 150) + '...'}
               </div>
             </motion.div>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import { FilterOption } from '@/app/(user)/saved-prompts/types/prompt';
+
 import config from '../../package.json';
 
 export const APP_VERSION = config.version;
@@ -10,3 +12,26 @@ export const RPC_URL =
 export const MAX_TOKEN_MESSAGES = 10;
 
 export const NO_CONFIRMATION_MESSAGE = ' (Does not require confirmation)';
+
+export const filterOptions: FilterOption[] = [
+  {
+    value: 'recentlyUsed',
+    label: 'Recently Used',
+  },
+  {
+    value: 'editedRecently',
+    label: 'Edited Recently',
+  },
+  {
+    value: 'latest',
+    label: 'Newest First',
+  },
+  {
+    value: 'oldest',
+    label: 'Oldest First',
+  },
+  {
+    value: 'favorites',
+    label: 'Favorites',
+  },
+];


### PR DESCRIPTION
Solves #176 

- [x] Add prompt filtering (Favorites, Recently Used, Recently Edited, etc.) in the homepage.
- [x] Persist users' selected filter preference in local storage, helping them land on their preferred view without reselecting filter each time they land on the homepage.
- [x] Add pagination to prompt lists to maintain UI consistency.

https://github.com/user-attachments/assets/65e30254-fba2-4e94-9280-739d5f7b04e8





