### PR TITLE
Update domain from neur.sh to neur.studio (main branch)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 neur.sh
+Copyright (c) 2024 neur.studio
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/LOCAL_DEV.md
+++ b/LOCAL_DEV.md
@@ -1,6 +1,6 @@
 # Local Development
 
-This describes steps to spin up Neur.sh locally:
+This describes steps to spin up Neur.studio locally:
 
 ## Environment Variables
 

--- a/src/ai/providers.tsx
+++ b/src/ai/providers.tsx
@@ -105,7 +105,7 @@ Response Formatting:
 - Use an abbreviated format for transaction signatures
 
 Common knowledge:
-- { token: NEUR, description: The native token of Neur, twitter: @neur_sh, website: https://neur.sh/, address: 3N2ETvNpPNAxhcaXgkhKoY1yDnQfs41Wnxsx5qNJpump }
+- { token: NEUR, description: The native token of Neur, twitter: @neur_sh, website: https://neur.studio/, address: 3N2ETvNpPNAxhcaXgkhKoY1yDnQfs41Wnxsx5qNJpump }
 - { user: toly, description: Co-Founder of Solana Labs, twitter: @aeyakovenko, wallet: toly.sol }\
 
 Realtime knowledge:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,7 +33,7 @@ import { cn } from '@/lib/utils';
 
 const navItems = [
   { label: 'Github', href: 'https://git.new/neur', icon: GitHubLogoIcon },
-  { label: 'Docs', href: 'https://docs.neur.sh', icon: BookOpenIcon },
+  { label: 'Docs', href: 'https://docs.neur.studio', icon: BookOpenIcon },
 ];
 
 const Header = ({ handleLogin }: { handleLogin: () => void }) => {

--- a/src/components/dashboard/app-sidebar-user.tsx
+++ b/src/components/dashboard/app-sidebar-user.tsx
@@ -103,7 +103,7 @@ export const AppSidebarUser = () => {
 
               {/* Docs */}
               <DropdownMenuItem
-                onClick={() => window.open('https://docs.neur.sh', '_blank')}
+                onClick={() => window.open('https://docs.neur.studio', '_blank')}
               >
                 <BookOpen className="mr-2 h-4 w-4" />
                 Docs

--- a/src/components/dashboard/app-sidebar.tsx
+++ b/src/components/dashboard/app-sidebar.tsx
@@ -29,7 +29,7 @@ const AppSidebarHeader = () => {
     <SidebarHeader>
       <div className="flex items-center justify-between px-1">
         <span className="pl-2 text-lg font-medium tracking-tight group-data-[collapsible=icon]:hidden">
-          neur.sh
+          neur.studio
         </span>
         <div className="flex items-center gap-1.5">
           <ThemeToggle />

--- a/src/components/referral-section.tsx
+++ b/src/components/referral-section.tsx
@@ -80,7 +80,7 @@ export function ReferralSection({
               <div className="flex items-center gap-2">
                 <Input
                   readOnly
-                  value={`https://neur.sh/?ref=${referralCode}`}
+                  value={`https://neur.studio/?ref=${referralCode}`}
                   className="flex-1 bg-background/50 font-mono text-sm"
                 />
                 <Button
@@ -88,7 +88,7 @@ export function ReferralSection({
                   size="sm"
                   className="min-w-[100px] text-xs"
                   onClick={() => {
-                    copyToClipboard(`https://neur.sh/?ref=${referralCode}`);
+                    copyToClipboard(`https://neur.studio/?ref=${referralCode}`);
                     setCopied(true);
                     setTimeout(() => setCopied(false), 2000);
                   }}


### PR DESCRIPTION
This PR updates all occurrences of `neur.sh` to `neur.studio` within the beta branch.

This change mirrors the previous PR to `main`, but has been applied directly to `beta` as per the request:
> "Originate in beta and get merged to main when there is a feature release."

Let me know if anything else is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated all references from "neur.sh" to "neur.studio" across the app, including website links, documentation URLs, referral links, and branding labels.
- **Documentation**
	- Updated the LICENSE and local development documentation to reflect the new "neur.studio" name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->