### PR TITLE
feat: add Solscan wallet analytics tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,5 @@ DISCORD_ROLE_ID=<optional>
 PRIVY_SIGNING_KEY=<optional>
 BIRDEYE_API_KEY=<optional>
 COOKIE_FUN_API_KEY=<optional>
+SOLSCAN_API_KEY=<optional>
+SOLSCAN_BASE_URL=https://pro-api.solscan.io/v2.0

--- a/src/ai/providers.tsx
+++ b/src/ai/providers.tsx
@@ -1,7 +1,5 @@
 import { ReactNode } from 'react';
 
-
-
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 import { z } from 'zod';
@@ -12,8 +10,8 @@ import { actionTools } from './generic/action';
 import { jinaTools } from './generic/jina';
 import { telegramTools } from './generic/telegram';
 import { utilTools } from './generic/util';
-import { bundleTools } from './solana/bundle';
 import { birdeyeTools } from './solana/birdeye';
+import { bundleTools } from './solana/bundle';
 import { chartTools } from './solana/chart';
 import { cookietools } from './solana/cookie';
 import { definedTools } from './solana/defined-fi';
@@ -22,6 +20,7 @@ import { jupiterTools } from './solana/jupiter';
 import { magicEdenTools } from './solana/magic-eden';
 import { pumpfunTools } from './solana/pumpfun';
 import { solanaTools } from './solana/solana';
+import { solscanTools } from './solana/solscan';
 
 const usingAnthropic = !!process.env.ANTHROPIC_API_KEY;
 
@@ -154,6 +153,7 @@ export function DefaultToolResultRenderer({ result }: { result: unknown }) {
 export const defaultTools: Record<string, ToolConfig> = {
   ...actionTools,
   ...solanaTools,
+  ...solscanTools,
   ...definedTools,
   ...pumpfunTools,
   ...jupiterTools,
@@ -213,9 +213,9 @@ export const toolsets: Record<
       'Web scraping and content extraction tools for reading web pages and extracting content.',
   },
   defiTools: {
-    tools: ['solanaTools', 'dexscreenerTools'],
+    tools: ['solanaTools', 'dexscreenerTools', 'solscanTools'],
     description:
-      'Tools for interacting with DeFi protocols on Solana, including swaps, market data, token information and details.',
+      'Tools for interacting with DeFi protocols on Solana, including swaps, market data, token information, wallet activity, and Solscan analytics.',
   },
   traderTools: {
     tools: ['birdeyeTools'],

--- a/src/ai/solana/solscan.tsx
+++ b/src/ai/solana/solscan.tsx
@@ -57,6 +57,17 @@ const ErrorCard = ({ error }: { error?: string }) => (
   </Card>
 );
 
+const toolResultSchema = z.union([
+  z.object({
+    success: z.literal(true),
+    data: z.unknown(),
+  }),
+  z.object({
+    success: z.literal(false),
+    error: z.string().optional(),
+  }),
+]);
+
 const TransactionsTable = ({
   transactions,
 }: {
@@ -198,11 +209,16 @@ const PortfolioCard = ({
 };
 
 const renderResult = <T,>(raw: unknown, render: (data: T) => ReactNode) => {
-  const result = raw as { success: boolean; data?: T; error?: string };
-  if (!result.success || result.data === undefined) {
-    return <ErrorCard error={result.error} />;
+  const result = toolResultSchema.safeParse(raw);
+  if (!result.success) {
+    return <ErrorCard />;
   }
-  return render(result.data);
+
+  if (!result.data.success) {
+    return <ErrorCard error={result.data.error} />;
+  }
+
+  return render(result.data.data as T);
 };
 
 export const solscanTools = {
@@ -236,11 +252,11 @@ export const solscanTools = {
       limit?: number;
     }) => {
       try {
-        const transactions = await getSolscanAccountTransactions({
+        const transactions = await getSolscanAccountTransactions(
           address,
           before,
           limit,
-        });
+        );
         return { suppressFollowUp: true, success: true, data: transactions };
       } catch (error) {
         return {
@@ -302,14 +318,14 @@ export const solscanTools = {
       toTime?: number;
     }) => {
       try {
-        const activities = await getSolscanAccountDefiActivities({
+        const activities = await getSolscanAccountDefiActivities(
           address,
           fromTime,
           page,
           pageSize,
           platform,
           toTime,
-        });
+        );
         return { suppressFollowUp: true, success: true, data: activities };
       } catch (error) {
         return {
@@ -338,7 +354,7 @@ export const solscanTools = {
     }),
     execute: async ({ address }: { address: string }) => {
       try {
-        const portfolio = await getSolscanAccountPortfolio({ address });
+        const portfolio = await getSolscanAccountPortfolio(address);
         return { suppressFollowUp: true, success: true, data: portfolio };
       } catch (error) {
         return {

--- a/src/ai/solana/solscan.tsx
+++ b/src/ai/solana/solscan.tsx
@@ -1,0 +1,358 @@
+import type { ReactNode } from 'react';
+
+import { ExternalLink } from 'lucide-react';
+import { z } from 'zod';
+
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { formatShortNumber, truncate } from '@/lib/utils/format';
+import {
+  type SolscanAccountPortfolio,
+  type SolscanAccountTransaction,
+  type SolscanDefiActivity,
+  getSolscanAccountDefiActivities,
+  getSolscanAccountPortfolio,
+  getSolscanAccountTransactions,
+} from '@/server/actions/solscan';
+import { publicKeySchema } from '@/types/util';
+
+const timestampLabel = (value?: number | string) => {
+  if (!value) return 'Unknown';
+  const date =
+    typeof value === 'number' ? new Date(value * 1000) : new Date(value);
+  return Number.isNaN(date.getTime()) ? 'Unknown' : date.toLocaleString();
+};
+
+const SolscanLink = ({
+  children,
+  path,
+}: {
+  children: ReactNode;
+  path: string;
+}) => (
+  <a
+    href={`https://solscan.io/${path}`}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center gap-1 hover:text-foreground"
+  >
+    {children}
+    <ExternalLink className="h-3 w-3" />
+  </a>
+);
+
+const ErrorCard = ({ error }: { error?: string }) => (
+  <Card className="bg-destructive/5 p-4">
+    <p className="text-sm text-destructive">
+      {error || 'Unable to load Solscan data.'}
+    </p>
+  </Card>
+);
+
+const TransactionsTable = ({
+  transactions,
+}: {
+  transactions: SolscanAccountTransaction[];
+}) => {
+  if (!transactions.length) {
+    return (
+      <Card className="bg-muted/50 p-4">
+        <p className="text-sm text-muted-foreground">
+          No recent Solscan transactions found.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="overflow-hidden bg-muted/50">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Signature</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Fee</TableHead>
+            <TableHead>Time</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {transactions.map((transaction) => (
+            <TableRow key={transaction.trans_id}>
+              <TableCell className="font-mono">
+                <SolscanLink path={`tx/${transaction.trans_id}`}>
+                  {truncate(transaction.trans_id, 6)}
+                </SolscanLink>
+              </TableCell>
+              <TableCell>
+                <Badge
+                  variant={
+                    transaction.status === 'Success' ? 'default' : 'secondary'
+                  }
+                >
+                  {transaction.status || 'Unknown'}
+                </Badge>
+              </TableCell>
+              <TableCell>
+                {typeof transaction.fee === 'number'
+                  ? `${formatShortNumber(transaction.fee)} lamports`
+                  : 'Unknown'}
+              </TableCell>
+              <TableCell>
+                {timestampLabel(transaction.block_time || transaction.time)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Card>
+  );
+};
+
+const DefiActivitiesTable = ({
+  activities,
+}: {
+  activities: SolscanDefiActivity[];
+}) => {
+  if (!activities.length) {
+    return (
+      <Card className="bg-muted/50 p-4">
+        <p className="text-sm text-muted-foreground">
+          No recent Solscan DeFi activities found.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="overflow-hidden bg-muted/50">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Activity</TableHead>
+            <TableHead>Platform</TableHead>
+            <TableHead>Signature</TableHead>
+            <TableHead>Time</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {activities.map((activity, index) => (
+            <TableRow key={`${activity.trans_id}-${index}`}>
+              <TableCell>{activity.activity_type || 'Unknown'}</TableCell>
+              <TableCell>{activity.platform || 'Unknown'}</TableCell>
+              <TableCell className="font-mono">
+                <SolscanLink path={`tx/${activity.trans_id}`}>
+                  {truncate(activity.trans_id, 6)}
+                </SolscanLink>
+              </TableCell>
+              <TableCell>
+                {timestampLabel(activity.block_time || activity.time)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Card>
+  );
+};
+
+const PortfolioCard = ({
+  portfolio,
+}: {
+  portfolio: SolscanAccountPortfolio;
+}) => {
+  const tokens = Array.isArray(portfolio.tokens) ? portfolio.tokens : [];
+
+  return (
+    <Card className="space-y-4 bg-muted/50 p-4">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="rounded-lg bg-background/50 p-3">
+          <div className="text-sm text-muted-foreground">Total value</div>
+          <div className="mt-1 text-2xl font-semibold">
+            {typeof portfolio.total_value === 'number'
+              ? `$${portfolio.total_value.toLocaleString(undefined, {
+                  maximumFractionDigits: 2,
+                })}`
+              : 'Unknown'}
+          </div>
+        </div>
+        <div className="rounded-lg bg-background/50 p-3">
+          <div className="text-sm text-muted-foreground">Token accounts</div>
+          <div className="mt-1 text-2xl font-semibold">
+            {tokens.length.toLocaleString()}
+          </div>
+        </div>
+      </div>
+      <pre className="max-h-[280px] overflow-auto whitespace-pre-wrap break-words rounded-lg bg-background/60 p-3 text-xs text-muted-foreground">
+        {JSON.stringify(portfolio, null, 2)}
+      </pre>
+    </Card>
+  );
+};
+
+const renderResult = <T,>(raw: unknown, render: (data: T) => ReactNode) => {
+  const result = raw as { success: boolean; data?: T; error?: string };
+  if (!result.success || result.data === undefined) {
+    return <ErrorCard error={result.error} />;
+  }
+  return render(result.data);
+};
+
+export const solscanTools = {
+  getSolscanAccountTransactions: {
+    displayName: 'Solscan Transactions',
+    isCollapsible: true,
+    isExpandedByDefault: true,
+    requiredEnvVars: ['SOLSCAN_API_KEY'],
+    description:
+      'Get recent historical Solana transactions for a wallet address from Solscan. Use this when users ask for wallet transaction history, recent activity, signatures, fees, or account activity timelines.',
+    parameters: z.object({
+      address: publicKeySchema.describe('The Solana wallet address to inspect'),
+      before: z
+        .string()
+        .optional()
+        .describe('Optional pagination cursor or signature before this page'),
+      limit: z
+        .number()
+        .min(1)
+        .max(40)
+        .optional()
+        .describe('Number of transactions to return, max 40'),
+    }),
+    execute: async ({
+      address,
+      before,
+      limit,
+    }: {
+      address: string;
+      before?: string;
+      limit?: number;
+    }) => {
+      try {
+        const transactions = await getSolscanAccountTransactions({
+          address,
+          before,
+          limit,
+        });
+        return { suppressFollowUp: true, success: true, data: transactions };
+      } catch (error) {
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : 'Failed to load Solscan transactions',
+        };
+      }
+    },
+    render: (raw: unknown) =>
+      renderResult<SolscanAccountTransaction[]>(raw, (transactions) => (
+        <TransactionsTable transactions={transactions} />
+      )),
+  },
+  getSolscanDefiActivities: {
+    displayName: 'Solscan DeFi Activity',
+    isCollapsible: true,
+    isExpandedByDefault: true,
+    requiredEnvVars: ['SOLSCAN_API_KEY'],
+    description:
+      'Get recent DeFi activities for a Solana wallet from Solscan. Use this for wallet analytics, smart money tracking, DEX activity, swaps, staking, liquidity, or protocol activity over a timeframe.',
+    parameters: z.object({
+      address: publicKeySchema.describe('The Solana wallet address to inspect'),
+      fromTime: z
+        .number()
+        .optional()
+        .describe('Optional Unix timestamp lower bound in seconds'),
+      page: z.number().min(1).optional().describe('Page number, default 1'),
+      pageSize: z
+        .number()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe('Page size; Solscan supports fixed sizes like 10/20/30/40'),
+      platform: z
+        .string()
+        .optional()
+        .describe('Optional Solscan platform filter'),
+      toTime: z
+        .number()
+        .optional()
+        .describe('Optional Unix timestamp upper bound in seconds'),
+    }),
+    execute: async ({
+      address,
+      fromTime,
+      page,
+      pageSize,
+      platform,
+      toTime,
+    }: {
+      address: string;
+      fromTime?: number;
+      page?: number;
+      pageSize?: number;
+      platform?: string;
+      toTime?: number;
+    }) => {
+      try {
+        const activities = await getSolscanAccountDefiActivities({
+          address,
+          fromTime,
+          page,
+          pageSize,
+          platform,
+          toTime,
+        });
+        return { suppressFollowUp: true, success: true, data: activities };
+      } catch (error) {
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : 'Failed to load Solscan DeFi activities',
+        };
+      }
+    },
+    render: (raw: unknown) =>
+      renderResult<SolscanDefiActivity[]>(raw, (activities) => (
+        <DefiActivitiesTable activities={activities} />
+      )),
+  },
+  getSolscanAccountPortfolio: {
+    displayName: 'Solscan Portfolio',
+    isCollapsible: true,
+    isExpandedByDefault: true,
+    requiredEnvVars: ['SOLSCAN_API_KEY'],
+    description:
+      'Get a Solana wallet portfolio from Solscan. Use this when users ask for token balances, account holdings, wallet analytics, or JSON output for a wallet.',
+    parameters: z.object({
+      address: publicKeySchema.describe('The Solana wallet address to inspect'),
+    }),
+    execute: async ({ address }: { address: string }) => {
+      try {
+        const portfolio = await getSolscanAccountPortfolio({ address });
+        return { suppressFollowUp: true, success: true, data: portfolio };
+      } catch (error) {
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : 'Failed to load Solscan portfolio',
+        };
+      }
+    },
+    render: (raw: unknown) =>
+      renderResult<SolscanAccountPortfolio>(raw, (portfolio) => (
+        <PortfolioCard portfolio={portfolio} />
+      )),
+  },
+};

--- a/src/server/actions/solscan.ts
+++ b/src/server/actions/solscan.ts
@@ -72,61 +72,66 @@ const solscanGet = async <T>(
     }
   });
 
-  const response = await fetch(url, {
-    next: { revalidate: 60 },
-    headers: {
-      accept: 'application/json',
-      token: apiKey,
-    },
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
 
-  if (!response.ok) {
-    throw new Error(`Solscan request failed with ${response.status}`);
+  try {
+    const response = await fetch(url, {
+      next: { revalidate: 60 },
+      headers: {
+        accept: 'application/json',
+        token: apiKey,
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Solscan request failed with ${response.status}`);
+    }
+
+    const parsedResponse = solscanResponseSchema.safeParse(
+      await response.json(),
+    );
+
+    if (!parsedResponse.success) {
+      throw new Error('Solscan request failed');
+    }
+
+    const parsed = parsedResponse.data;
+
+    if (!parsed.success) {
+      throw new Error(parsed.errors?.message || 'Solscan request failed');
+    }
+
+    return parsed.data as T;
+  } finally {
+    clearTimeout(timeout);
   }
-
-  const parsed = solscanResponseSchema.parse(await response.json());
-
-  if (!parsed.success) {
-    throw new Error(parsed.errors?.message || 'Solscan request failed');
-  }
-
-  return parsed.data as T;
 };
 
 export const getSolscanAccountTransactions = cache(
-  async ({
-    address,
-    before,
+  async (
+    address: string,
+    before?: string,
     limit = 10,
-  }: {
-    address: string;
-    before?: string;
-    limit?: number;
-  }): Promise<SolscanAccountTransaction[]> => {
+  ): Promise<SolscanAccountTransaction[]> => {
     return solscanGet<SolscanAccountTransaction[]>('/account/transactions', {
       address,
       before,
-      limit: Math.max(10, Math.min(limit, 40)),
+      limit: Math.min(Math.max(limit, 1), 40),
     });
   },
 );
 
 export const getSolscanAccountDefiActivities = cache(
-  async ({
-    address,
-    fromTime,
+  async (
+    address: string,
+    fromTime?: number,
     page = 1,
     pageSize = 10,
-    platform,
-    toTime,
-  }: {
-    address: string;
-    fromTime?: number;
-    page?: number;
-    pageSize?: number;
-    platform?: string;
-    toTime?: number;
-  }): Promise<SolscanDefiActivity[]> => {
+    platform?: string,
+    toTime?: number,
+  ): Promise<SolscanDefiActivity[]> => {
     return solscanGet<SolscanDefiActivity[]>('/account/defi/activities', {
       address,
       from_time: fromTime,
@@ -141,11 +146,7 @@ export const getSolscanAccountDefiActivities = cache(
 );
 
 export const getSolscanAccountPortfolio = cache(
-  async ({
-    address,
-  }: {
-    address: string;
-  }): Promise<SolscanAccountPortfolio> => {
+  async (address: string): Promise<SolscanAccountPortfolio> => {
     return solscanGet<SolscanAccountPortfolio>('/account/portfolio', {
       address,
     });

--- a/src/server/actions/solscan.ts
+++ b/src/server/actions/solscan.ts
@@ -1,0 +1,153 @@
+import { cache } from 'react';
+
+import { z } from 'zod';
+
+const SOLSCAN_BASE_URL =
+  process.env.SOLSCAN_BASE_URL || 'https://pro-api.solscan.io/v2.0';
+
+const PAGE_SIZE_OPTIONS = [10, 20, 30, 40, 60, 100] as const;
+
+const solscanResponseSchema = z.object({
+  success: z.boolean(),
+  data: z.unknown().optional(),
+  errors: z
+    .object({
+      code: z.number().optional(),
+      message: z.string().optional(),
+    })
+    .optional(),
+});
+
+export interface SolscanAccountTransaction {
+  block_id?: number;
+  block_time?: number;
+  fee?: number;
+  signer?: string[];
+  status?: string;
+  trans_id: string;
+  time?: string;
+}
+
+export interface SolscanDefiActivity {
+  activity_type?: string;
+  block_id?: number;
+  block_time?: number;
+  from_address?: string;
+  platform?: string;
+  routers?: Array<Record<string, unknown>>;
+  sources?: string[];
+  time?: string;
+  to_address?: string;
+  trans_id: string;
+}
+
+export interface SolscanAccountPortfolio {
+  tokens?: Array<Record<string, unknown>>;
+  total_value?: number;
+  native_balance?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+const normalizePageSize = (pageSize?: number) => {
+  if (!pageSize) return 10;
+  return PAGE_SIZE_OPTIONS.reduce((best, option) =>
+    Math.abs(option - pageSize) < Math.abs(best - pageSize) ? option : best,
+  );
+};
+
+const solscanGet = async <T>(
+  endpoint: string,
+  params: Record<string, string | number | boolean | undefined>,
+): Promise<T> => {
+  const apiKey = process.env.SOLSCAN_API_KEY;
+
+  if (!apiKey) {
+    throw new Error('SOLSCAN_API_KEY is required to use Solscan tools');
+  }
+
+  const url = new URL(`${SOLSCAN_BASE_URL}${endpoint}`);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== '') {
+      url.searchParams.set(key, String(value));
+    }
+  });
+
+  const response = await fetch(url, {
+    next: { revalidate: 60 },
+    headers: {
+      accept: 'application/json',
+      token: apiKey,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Solscan request failed with ${response.status}`);
+  }
+
+  const parsed = solscanResponseSchema.parse(await response.json());
+
+  if (!parsed.success) {
+    throw new Error(parsed.errors?.message || 'Solscan request failed');
+  }
+
+  return parsed.data as T;
+};
+
+export const getSolscanAccountTransactions = cache(
+  async ({
+    address,
+    before,
+    limit = 10,
+  }: {
+    address: string;
+    before?: string;
+    limit?: number;
+  }): Promise<SolscanAccountTransaction[]> => {
+    return solscanGet<SolscanAccountTransaction[]>('/account/transactions', {
+      address,
+      before,
+      limit: Math.max(10, Math.min(limit, 40)),
+    });
+  },
+);
+
+export const getSolscanAccountDefiActivities = cache(
+  async ({
+    address,
+    fromTime,
+    page = 1,
+    pageSize = 10,
+    platform,
+    toTime,
+  }: {
+    address: string;
+    fromTime?: number;
+    page?: number;
+    pageSize?: number;
+    platform?: string;
+    toTime?: number;
+  }): Promise<SolscanDefiActivity[]> => {
+    return solscanGet<SolscanDefiActivity[]>('/account/defi/activities', {
+      address,
+      from_time: fromTime,
+      page: Math.max(1, page),
+      page_size: normalizePageSize(pageSize),
+      platform,
+      sort_by: 'block_time',
+      sort_order: 'desc',
+      to_time: toTime,
+    });
+  },
+);
+
+export const getSolscanAccountPortfolio = cache(
+  async ({
+    address,
+  }: {
+    address: string;
+  }): Promise<SolscanAccountPortfolio> => {
+    return solscanGet<SolscanAccountPortfolio>('/account/portfolio', {
+      address,
+    });
+  },
+);

--- a/src/server/actions/solscan.ts
+++ b/src/server/actions/solscan.ts
@@ -85,13 +85,17 @@ const solscanGet = async <T>(
       signal: controller.signal,
     });
 
-    if (!response.ok) {
-      throw new Error(`Solscan request failed with ${response.status}`);
-    }
+    const body = await response.json().catch(() => undefined);
+    const parsedResponse = solscanResponseSchema.safeParse(body);
 
-    const parsedResponse = solscanResponseSchema.safeParse(
-      await response.json(),
-    );
+    if (!response.ok) {
+      throw new Error(
+        parsedResponse.success
+          ? parsedResponse.data.errors?.message ||
+            `Solscan request failed with ${response.status}`
+          : `Solscan request failed with ${response.status}`,
+      );
+    }
 
     if (!parsedResponse.success) {
       throw new Error('Solscan request failed');


### PR DESCRIPTION
Closes #47.

## Summary
- Adds Solscan-backed wallet analytics tools for account transactions, DeFi activities, and portfolio lookup.
- Renders transaction and DeFi activity tables with Solscan links, plus portfolio summary and JSON details.
- Registers the tools in the DeFi toolset and documents SOLSCAN_API_KEY / SOLSCAN_BASE_URL.

## Verification
- prettier --check .env.example src/ai/providers.tsx src/ai/solana/solscan.tsx src/server/actions/solscan.ts
- prisma generate
- 	sc --noEmit --pretty false currently reaches an existing install limitation: solana-agent-kit is unavailable because the git-hosted dependency build scripts are blocked unless allowlisted; no Solscan files are reported in the type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Solscan-backed wallet transactions, DeFi activity, and portfolio data retrieval.
  * Introduced Solscan result views in the app, including a transactions table, DeFi activities table, and a portfolio summary card.
  * Expanded AI tool configuration to support Solscan analytics and related Solana DeFi capabilities.
* **Bug Fixes**
  * Improved data validation and error handling for Solscan responses, with consistent error display in the UI.
* **Chores**
  * Updated the sample environment configuration with required Solscan settings (`SOLSCAN_API_KEY`, `SOLSCAN_BASE_URL`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->